### PR TITLE
Add end to end GSC image curation tool

### DIFF
--- a/Curated-Apps/.gitignore
+++ b/Curated-Apps/.gitignore
@@ -1,0 +1,1 @@
+/commands.txt

--- a/Curated-Apps/README.md
+++ b/Curated-Apps/README.md
@@ -1,0 +1,66 @@
+# Gramine Curated Applications
+
+The Gramine Curated applications project provides an interactive script that helps to transform any
+Docker image to a graminized one, packing features such as attestation and beyond, necessary for
+enabling end-to-end use cases securely. The interactive script asks users for specific
+requirements, and submits the user inputs to the [GSC tool](https://github.com/gramineproject/gsc).
+A list of workload examples are provided below for reference. One can easily extend these reference
+examples to support more workloads by inspecting the contents of any of the reference workloads
+(e.g. `workloads/redis/` directory), understand how they work, and then use them as the basis for
+ their own workloads. The script also provides a `test` feature where, with a single command, users
+can generate a non-production GSC image, signed with a dummy key, purely for experimentation and
+learning.
+
+## Prerequisites
+
+### For building curated GSC image
+- No hardware requirements.
+- Any regular system with a Linux distribution is sufficient.
+- Install the necessary build dependencies as shown below (for Ubuntu).
+```sh
+ $ sudo apt-get update && sudo apt-get install jq docker.io python3 python3-pip
+ $ pip3 install docker jinja2 toml pyyaml
+ $ sudo chown $USER /var/run/docker.sock
+```
+
+### For running the curated GSC image
+1. [Create an Intel SGX VM from the Azure portal](https://learn.microsoft.com/en-us/azure/confidential-computing/quick-create-portal).
+   The tested distros are Ubuntu and Debian. Selection of a VM must factor in the EPC size that
+   suits the application.
+2. Install the necessary build dependencies as shown below (for Ubuntu 18.04).
+   ```sh
+   $ sudo apt-get update && sudo apt-get install -y docker.io
+   $ sudo chown $USER /var/run/docker.sock
+   $ echo 'deb [arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu bionic main' |
+     sudo tee /etc/apt/sources.list.d/intel-sgx.list
+   $ wget -qO - https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key |
+     sudo apt-key add -
+   $ sudo apt-key adv --fetch-keys https://packages.microsoft.com/keys/microsoft.asc
+   $ sudo apt-add-repository 'https://packages.microsoft.com/ubuntu/18.04/prod main'
+   $ sudo apt update && sudo apt install -y az-dcap-client
+   $ sudo apt-get install -y -f libsgx-dcap-ql
+   ```
+
+## Interactive script usage
+`$ python3 curate.py <workload type> <base image name> <optional args>`
+
+    |---------------------------------------------------------------------------------------------|
+    | Required?| Argument         | Description/Possible values                                   |
+    |----------|------------------|---------------------------------------------------------------|
+    |    Yes   | <workload type>  | Provide type of workload e.g. redis or pytorch                |
+    |    Yes   | <base image name>| Base image name to be graminized.                             |
+    | Optional | 'debug'          | To generate an insecure graminized image with debug symbols.  |
+    | Optional | 'test'           | To generate an insecure image with a test enclave signing key.|
+    |---------------------------------------------------------------------------------------------|
+
+## Sample Workloads
+`workloads/` subdirectory contains relevant instructions and support files to curate a selected
+ set of applications with Gramine.
+
+## Contents
+
+    .
+    |-- curate.py               # Entry file for curation that the user runs as explained above
+    |-- util/                   # Helper scripts and files that curate.py uses
+    |-- verifier/               # Contents to build attestation verifier image
+    |-- workloads/              # Sample curated applications for select set of workloads

--- a/Curated-Apps/curate.py
+++ b/Curated-Apps/curate.py
@@ -1,0 +1,504 @@
+#!/usr/bin/python
+# SPDX-License-Identifier: LGPL-3.0-or-later
+# Copyright (C) 2022 Intel Corporation
+
+# This script will provide step-by-step guidance in creating your own custom Docker images
+# protected by Gramine. User will be prompted for input at every stage, and once the script has all
+# the details, it will call a separate curation script (util/curation_script.sh) that takes the
+# user provided inputs to create the graminized Docker image using GSC. This script also calls into
+# another script (verifier/helper.sh) to generate the verifier Docker image (for SGX remote
+# attestation). The generated verifier Docker image must be started on a trusted remote
+# system before the graminized Docker image is deployed at the target system, to verify the SGX
+# attestation evidence (SGX quote) sent by the latter image.
+
+import curses
+import docker
+import os
+import os.path
+import re
+import subprocess
+import sys
+import textwrap
+import time
+
+from cProfile import label
+from util.constants import *
+from curses import KEY_BACKSPACE, wrapper
+from curses.textpad import Textbox, rectangle
+from glob import escape
+from os import path
+from sys import argv
+
+# Following are the command line parameters accepted by this script:
+usage = '''
+|---------------------------------------------------------------------------------------------|
+| Required?| Argument         | Description/Possible values                                   |
+|----------|------------------|---------------------------------------------------------------|
+|    Yes   | <workload type>  | Provide type of workload e.g. redis or pytorch                |
+|    Yes   | <base image name>| Base image name to be graminized.                             |
+| Optional | 'debug'          | To generate an insecure graminized image with debug symbols.  |
+| Optional | 'test'           | To generate an insecure image with a test enclave signing key.|
+|---------------------------------------------------------------------------------------------|
+'''
+# -------GUI curses interfaces--------------------------------------------------------------------
+def initwindows():
+    curses.init_pair(1, curses.COLOR_WHITE, curses.COLOR_BLACK)
+    curses.init_pair(2, curses.COLOR_WHITE, curses.COLOR_BLUE)
+    curses.init_pair(3, curses.COLOR_RED, curses.COLOR_BLACK)
+
+    WHITE_AND_BLACK = curses.color_pair(1)
+    WHITE_AND_BLUE = curses.color_pair(2)
+
+    title_win = curses.newwin(title_height, title_width, 0, 0)
+    user_console = curses.newwin(user_console_height, user_console_width, title_height, 0)
+    guide_win = curses.newwin(guide_win_height, guide_win_width, title_height,
+                              int(screen_width/2))
+    partition_win = curses.newwin(partition_height, partition_width, partition_y,
+                                  int(sub_title_width) - 2)
+
+    title_win.addstr(0, 0, ' ' * title_width, WHITE_AND_BLUE)
+    title_win.addstr(0, int((title_width/2) - (len(title)/2)), title,
+                     WHITE_AND_BLUE | curses.A_BOLD)
+
+    sub_win_title = user_win_title
+    sub_title_ind = 1
+
+    input_start_y, input_start_x = 2 , int((sub_title_ind * sub_title_width) - (sub_title_width / 2)
+                                            - len(sub_win_title)/2)
+    title_win.addstr(input_start_y, input_start_x, sub_win_title,
+                     WHITE_AND_BLACK | curses.A_BOLD | curses.A_UNDERLINE)
+
+    partition_win.bkgd(' ', curses.color_pair(2) | curses.A_BOLD)
+    partition_win.refresh()
+
+    sub_win_title = help_win_title
+    sub_title_ind = 2
+    input_start_y, input_start_x = 2 , int((sub_title_ind * sub_title_width)
+                                           - (sub_title_width / 2) - len(sub_win_title)/2)
+    title_win.addstr(input_start_y, input_start_x, sub_win_title,
+                     WHITE_AND_BLACK | curses.A_BOLD | curses.A_UNDERLINE)
+    title_win.refresh()
+    return(user_console, guide_win)
+
+def resize_screen(screen_height, screen_width):
+    subprocess.call(['echo','-e',f'\x1b[8;{screen_height};{screen_width}t'])
+    time.sleep(0.35)
+
+def print_correct_usage(win, arg):
+    win.addstr(usage)
+    win.addstr('Press any key to exit')
+    win.getch()
+    sys.exit(1)
+
+def update_user_input(secure=False):
+    editwin = curses.newwin(user_input_height, user_input_width, user_input_start_y, 0)
+    editwin.bkgd(' ', curses.color_pair(2) | curses.A_BOLD)
+    box = Textbox(editwin)
+    if secure:
+        user_input = secure_box_edit(box)
+    else:
+        box.edit()
+        editwin.refresh()
+        user_input = box.gather().strip().replace('\n', '')
+    editwin.erase()
+    editwin.refresh()
+    return user_input
+
+def secure_box_edit(box):
+    user_inp_arr = []
+    while 1:
+        ch = box.win.getch()
+        if ch == CTRL_G:
+            break
+        if ch == KEY_BACKSPACE:
+            if len(user_inp_arr) > 0:
+                user_inp_arr.pop()
+        else:
+            user_inp_arr.append(chr(ch))
+        if not ch:
+            continue
+        if not box.do_command(ch):
+            break
+        [y, x] = box.win.getyx()
+        if x > 0:
+            box.win.addstr(y, int(x - 1), '*')
+        box.win.refresh()
+    return ''.join(user_inp_arr)
+
+def update_user_and_commentary_win(user_console, guide_win, user_text, help_text, offset):
+    user_console.erase()
+    guide_win.erase()
+    user_console.addstr(offset, 0, textwrap.fill(user_text, user_console_width))
+    guide_win.addstr(offset, 0, textwrap.fill(help_text, guide_win_width))
+
+    user_console.refresh()
+    guide_win.refresh()
+
+def update_user_and_commentary_win_array(user_console, guide_win, user_text_arr, help_text_arr):
+    user_console.erase()
+    guide_win.erase()
+
+    for user_text in user_text_arr:
+        color = 0
+        if user_text.find(color_set) >= 0:
+            color = curses.color_pair(2) | curses.A_REVERSE
+            user_text = user_text.replace(color_set , '')
+        [y, x] = user_console.getyx()
+        user_console.addstr(y + line_offset, 0, textwrap.fill(user_text, user_console_width),
+                            color)
+    for help_text in help_text_arr:
+        color = 0
+        if help_text.find(color_set) >= 0:
+            color = curses.color_pair(2) | curses.A_REVERSE
+            help_text = help_text.replace(color_set , '')
+        [y, x] = guide_win.getyx()
+        guide_win.addstr(y + line_offset, 0, textwrap.fill(help_text, guide_win_width), color)
+    user_console.refresh()
+    guide_win.refresh()
+
+def update_user_error_win(user_console, error_text):
+    [y, _] = user_console.getyx()
+    user_console.addstr(y + 2, 0, textwrap.fill(error_text, user_console_width), curses.A_BOLD
+                        | curses.color_pair(3))
+    user_console.refresh()
+
+def edit_user_win(user_console, error_text):
+    [y, _] = user_console.getyx()
+    user_console.addstr(y + line_offset, 0, textwrap.fill(error_text, user_console_width))
+    user_console.refresh()
+
+def update_run_win(text):
+    editwin = curses.newwin(user_input_height, user_input_width, user_input_start_y, 0)
+    editwin.bkgd(' ', curses.color_pair(2) | curses.A_BOLD)
+
+    start = 0
+    for text_input in text:
+        editwin.addstr(start, 0, textwrap.fill(text_input, user_input_width),
+                       curses.color_pair(2) | curses.A_BOLD)
+        start = start + 2
+
+    editwin.refresh()
+
+# --------docker image curation support interfaces------------------------------------------------
+def get_docker_image(docker_socket, image_name):
+    try:
+        docker_image = docker_socket.images.get(image_name)
+        return docker_image
+    except (docker.errors.ImageNotFound, docker.errors.APIError):
+        return None
+
+def check_image_creation_success(win, docker_socket, image_name, log_file):
+    image = get_docker_image(docker_socket, image_name)
+    if image is None:
+        win.addstr(f'\n\n\n`{image_name}` creation failed, exiting....')
+        win.addstr(f'For more info, look at the log file here: {log_file}')
+        win.getch()
+        sys.exit(1)
+
+def pull_docker_image(win, docker_socket, image_name):
+    try:
+        docker_image = docker_socket.images.pull(image_name)
+        return 0
+    except (docker.errors.ImageNotFound, docker.errors.APIError):
+        win.addstr(f'Error: Could not fetch `{image_name}` image from DockerHub.\n')
+        win.addstr('Please check if the image name is correct and try again.')
+        win.refresh()
+        return -1
+
+def get_encryption_key_input(user_console, guide_win):
+    file = update_user_input()
+    while not path.isfile(file):
+        user_console.erase()
+        update_user_and_commentary_win_array(user_console, guide_win, encrypted_files_prompt,
+                                             encypted_files_help)
+        edit_user_win(user_console, encryption_key_prompt)
+        update_user_error_win(user_console, file_not_found_error.format(file))
+        file = update_user_input()
+    return file
+
+# User is expected to provide the path to a signing key or `test` as input.
+# `test` as an input will result in generating a test signing key which is insecure for use in
+# production!
+def get_enclave_signing_input(user_console, guide_win):
+    sign_file = update_user_input()
+    while not path.isfile(sign_file) and sign_file != 'test':
+        error = "Please provide a valid input"
+        if sign_file != '':
+            error = file_not_found_error.format(sign_file)
+        user_console.erase()
+        update_user_and_commentary_win_array(user_console, guide_win, key_prompt, signing_key_help)
+        update_user_error_win(user_console, error)
+        sign_file = update_user_input()
+    return sign_file
+
+def get_attestation_input(user_console, guide_win):
+    attestation_input = update_user_input()
+    while True:
+        while (attestation_input not in ['test', 'done', '']):
+            user_console.erase()
+            update_user_and_commentary_win_array(user_console, guide_win, attestation_prompt,
+                                                 attestation_help)
+            update_user_error_win(user_console, 'Invalid option specified')
+            attestation_input = update_user_input()
+        if attestation_input == 'done':
+            if (path.isfile('verifier/ssl/ca.crt') and
+                path.isfile('verifier/ssl/server.crt') and
+                path.isfile('verifier/ssl/server.key')):
+                return attestation_input
+            user_console.erase()
+            update_user_and_commentary_win_array(user_console, guide_win, attestation_prompt,
+                                                 attestation_help)
+            update_user_error_win(user_console, 'One or more files does not exist at'
+                                  ' verifier/ssl/ directory')
+            attestation_input = update_user_input()
+            continue
+        return attestation_input
+
+def is_azure_instance():
+    service_cmd = "systemctl --type=service --state=running"
+    service_output = subprocess.run(service_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                                    universal_newlines=True, shell=True)
+    re_pattern='wa.*?agent.service.*?Azure.*'
+    rec_pattern = re.compile(re_pattern, re.VERBOSE)
+
+    return len(rec_pattern.findall(service_output.stdout)) > 0
+
+def main(stdscr, argv):
+
+    if len(argv) < 3:
+        print_correct_usage(stdscr, argv[0])
+
+    workload_type = argv[1]
+    base_image_name = argv[2]
+    debug_flag = 'n'
+    test_flag = ''
+    processed_args = 3
+    while processed_args < len(argv):
+        if argv[processed_args] == 'debug':
+            debug_flag = 'y'
+            processed_args += 1
+        elif argv[processed_args] == 'test':
+            test_flag = 'test'
+            processed_args += 1
+        else:
+            print_correct_usage(stdscr, argv[0])
+
+    stdscr.clear()
+    resize_screen(screen_height, screen_width)
+    stdscr = curses.initscr()
+
+    docker_socket = docker.from_env()
+    base_image = get_docker_image(docker_socket, base_image_name)
+    if base_image is None:
+        stdscr.addstr(image_not_found_warn.format(base_image_name))
+        stdscr.refresh()
+        if pull_docker_image(stdscr, docker_socket, base_image_name) == -1:
+            stdscr.getch()
+            return -1
+
+    log_file_name, n = re.subn('[:/]', '_', base_image_name)
+    log_file = f'workloads/{workload_type}/{log_file_name}.log'
+    log_file_pointer = open(log_file, 'w')
+
+    gsc_app_image ='gsc-{}'.format(base_image_name)
+    gsc_app_image_unsigned ='gsc-{}-unsigned'.format(base_image_name)
+
+    distro = 'ubuntu:18.04'
+    # Generating test image
+    if test_flag:
+        stdscr.addstr(test_image_mssg)
+        stdscr.addstr(log_progress.format(log_file))
+        stdscr.refresh()
+        subprocess.call(['util/curation_script.sh', workload_type, base_image_name, distro,
+                         'test', '', 'test-image', debug_flag], stdout=log_file_pointer,
+                         stderr=log_file_pointer)
+        check_image_creation_success(stdscr, docker_socket, gsc_app_image, log_file)
+        string_t = test_run_cmd.format(gsc_app_image)
+        stdscr.addstr(test_run_instr.format(gsc_app_image, string_t))
+
+        commands_fp = open(commands_file, 'w')
+        commands_fp.write(test_run_cmd.format(gsc_app_image))
+        commands_fp.close()
+
+        stdscr.getch()
+        return 0
+
+    user_console, guide_win = initwindows()
+
+    update_user_and_commentary_win_array(user_console, guide_win, introduction, index)
+    update_user_input()
+
+    if not is_azure_instance():
+        update_user_and_commentary_win_array(user_console, guide_win, azure_warning, azure_help)
+        update_user_input()
+
+    # 1. Obtain distro version
+    update_user_and_commentary_win_array(user_console, guide_win, distro_prompt, distro_help)
+    distro_option = update_user_input()
+    if distro_option == '2':
+        distro = 'ubuntu:20.04'
+    elif distro_option == '3' or distro_option == '4':
+        distro = 'debian:11'
+
+    # 2. Provide command-line arguments
+    update_user_and_commentary_win_array(user_console, guide_win, arg_input, arg_help)
+    args = update_user_input()
+
+    # 3. Provide environment variables
+    update_user_and_commentary_win_array(user_console, guide_win, env_input, env_help)
+    env_required = 'n'
+    envs = update_user_input()
+    if envs:
+        env_required = 'y'
+
+    # 4. Provide encrypted files and key provisioning
+    ef_required = 'n'
+    encryption_key = ''
+    enc_key_path_in_verifier = ''
+    encrypted_files = ''
+    update_user_and_commentary_win_array(user_console, guide_win, encrypted_files_prompt,
+                                         encypted_files_help)
+    encrypted_files = update_user_input()
+
+    if encrypted_files:
+        edit_user_win(user_console, encryption_key_prompt)
+        encryption_key = get_encryption_key_input(user_console, guide_win)
+        encryption_key_name = os.path.basename(encryption_key)
+        enc_key_path_in_verifier = enc_key_path.format(encryption_key_name)
+        ef_required = 'y'
+
+    # 5. Remote Attestation with RA-TLS
+    ca_cert_path = ''
+    config = ''
+    verifier_server = '<verifier-dns-name:port>'
+    attestation_required = 'n'
+    host_net = ''
+    update_user_and_commentary_win_array(user_console, guide_win, attestation_prompt,
+                                         attestation_help)
+    while True:
+        attestation_input = get_attestation_input(user_console, guide_win)
+        if attestation_input == 'done':
+            attestation_required = 'y'
+            ca_cert_path = ssl_folder_path_on_host+'/ca.crt'
+
+        elif attestation_input == 'test':
+            ca_cert_path, verifier_server = ssl_folder_path_on_host+'/ca.crt', '"localhost:4433"'
+            host_net, config = '--net=host', 'test'
+            attestation_required = 'y'
+
+        if ef_required == 'y' and attestation_required == 'n':
+            user_console.erase()
+            update_user_and_commentary_win_array(user_console, guide_win, attestation_prompt,
+                                                 attestation_help)
+            error = ('You require Remote Attestation to provision the key for encrypted files.')
+            update_user_error_win(user_console, error)
+            continue
+
+        break
+
+    # 6. Obtain enclave signing key
+    update_user_and_commentary_win_array(user_console, guide_win, key_prompt, signing_key_help)
+    key_path = get_enclave_signing_input(user_console, guide_win)
+    passphrase = ''
+    if key_path == 'test':
+        config = 'test'
+    else:
+        user_console.erase()
+        update_user_and_commentary_win_array(user_console, guide_win, key_prompt, signing_key_help)
+        edit_user_win(user_console, '>> Please enter the passphrase for the signing key'
+                      ' (no input will assume a passphrase-less key)'
+                      '                   Press CTRL+G to continue')
+        passphrase = update_user_input(secure=True)
+
+    # 7. Generation of the final curated images
+    if attestation_required == 'y':
+        os.chdir('verifier')
+        verifier_log_file_pointer = open(verifier_log_file, 'w')
+        update_user_and_commentary_win_array(user_console, guide_win, [verifier_build_messg],
+                                             [verifier_log_help.format(verifier_log_file)])
+        subprocess.call(['./helper.sh', attestation_input, ef_required,
+                         enc_key_path_in_verifier], stdout=verifier_log_file_pointer,
+                         stderr=verifier_log_file_pointer)
+        os.chdir('../')
+        check_image_creation_success(user_console, docker_socket,'verifier:latest',
+                                     'verifier/'+verifier_log_file)
+
+    update_user_and_commentary_win_array(user_console, guide_win, wait_message,
+                                         [log_progress.format(log_file)])
+    subprocess.call(['util/curation_script.sh', workload_type, base_image_name, distro,
+                     key_path, args, attestation_required, debug_flag, ca_cert_path, env_required,
+                     envs, ef_required, encrypted_files, passphrase], stdout=log_file_pointer,
+                     stderr=log_file_pointer)
+    image = gsc_app_image
+    check_image_creation_success(user_console, docker_socket, image, log_file)
+
+    # 8. Generation of docker run commands
+    commands_fp = open(commands_file, 'w')
+    if attestation_required == 'y':
+        debug_enclave_env_ver_ext = ''
+        if config == 'test':
+            debug_enclave_env_ver_ext = debug_enclave_env_verifier
+
+        ssl_folder_abs_path_on_host = os.path.abspath(ssl_folder_path_on_host)
+        verifier_cert_mount_str = verifier_cert_mount.format(ssl_folder_abs_path_on_host)
+        enc_keys_mount_str, enc_keys_path_str = '' , ''
+        if encryption_key:
+            key_name_and_path = os.path.abspath(encryption_key).rsplit('/', 1)
+            enc_keys_mount_str =  enc_keys_mount.format(key_name_and_path[0])
+
+        mr_enclave = '<mr_enclave>'
+        mr_signer = '<mr_signer>'
+        isv_prod_id = '<isv_prod_id>'
+        isv_svn = '<isv_svn>'
+
+        with open(log_file, 'r') as pfile:
+            lines = pfile.read()
+        pattern_enclave = re.compile('mr_enclave = \"(.*)\"')
+        pattern_signer = re.compile('mr_signer = \"(.*)\"')
+        pattern_isv_prod_id = re.compile('isv_prod_id = (.*)')
+        pattern_isv_svn = re.compile('isv_svn = (.*)')
+
+        mr_enclave_list = pattern_enclave.findall(lines)
+        mr_signer_list = pattern_signer.findall(lines)
+        isv_prod_id_list = pattern_isv_prod_id.findall(lines)
+        isv_svn_list = pattern_isv_svn.findall(lines)
+
+        if len(mr_enclave_list) > 0: mr_enclave = mr_enclave_list[0]
+        if len(mr_signer_list) > 0: mr_signer = mr_signer_list[0]
+        if len(isv_prod_id_list) > 0: isv_prod_id = isv_prod_id_list[0]
+        if len(isv_svn_list) > 0: isv_svn = isv_svn_list[0]
+
+        verifier_run_command = (f'Execute below command to start verifier on a trusted system:\n'
+                                f'$ docker run {host_net} --device=/dev/sgx/enclave '
+                                f'-e RA_TLS_MRENCLAVE={mr_enclave} -e RA_TLS_MRSIGNER={mr_signer} '
+                                f'-e RA_TLS_ISV_PROD_ID={isv_prod_id} -e RA_TLS_ISV_SVN={isv_svn} '
+                                f'{debug_enclave_env_ver_ext}' + verifier_cert_mount_str + ' ' +
+                                enc_keys_mount_str + ' -it verifier:latest')
+        custom_image_dns_info = ''
+        if config != 'test':
+            custom_image_dns_info = ('. Assign the correct DNS information of the verifier server to'
+                                     ' the environment variable SECRET_PROVISION_SERVERS')
+        run_command = (f'{verifier_run_command} \n \n'
+                       f'Execute below command to deploy the curated GSC image'
+                       f'{custom_image_dns_info}:\n'
+                       f'{workload_run.format(host_net, verifier_server, gsc_app_image)}')
+    else:
+        run_command = run_command_no_att.format(host_net, gsc_app_image)
+
+    user_info = [image_ready_messg.format(gsc_app_image), commands_file + color_set,
+                app_exit_messg]
+    commands_fp.write(run_command)
+    commands_fp.close()
+
+    debug_help = [debug_run_messg, run_with_debug.format(workload_type, base_image_name),
+                  extra_debug_instr.format(workload_type)]
+    if debug_flag == 'y':
+        debug_help = [extra_debug_instr.format(workload_type)]
+    update_user_and_commentary_win_array(user_console, guide_win, user_info, debug_help)
+
+    # Exit application with CTRL+G
+    while (user_console.getch() != CTRL_G):
+        continue
+    return 0
+
+wrapper(main, argv)

--- a/Curated-Apps/util/.gitignore
+++ b/Curated-Apps/util/.gitignore
@@ -1,0 +1,2 @@
+/__pycache__
+/config.yaml

--- a/Curated-Apps/util/config.yaml.template
+++ b/Curated-Apps/util/config.yaml.template
@@ -1,0 +1,28 @@
+# DO NOT CHANGE! BELOW WILL BE REPLACED BY THE CURATION SCRIPT!
+# Currently tested distros are
+# - ubuntu:18.04, ubuntu:20.04, ubuntu:21.04
+# - debian:10, debian:11
+
+Distro: "ubuntu:18.04"
+
+# If the image has a specific registry, define it here.
+# Empty by default; example value: "registry.access.redhat.com/ubi8".
+Registry: ""
+
+# If you're using your own fork and branch of Gramine, specify the GitHub link and the branch name
+# below; typically, you want to keep the default values though
+Gramine:
+    Repository: "https://github.com/gramineproject/gramine.git"
+    Branch:     "v1.3"
+
+# Specify the Intel SGX driver installed on your target machine (more specifically, on the machine
+# where the graminized Docker container will run); Default assumption is DCAP out-of-tree driver,
+# but for DCAP in-kernel driver: use empty values like below
+#
+#   - DCAP in-kernel driver: use empty values like below
+#         Repository: ""
+#         Branch:     ""
+#
+SGXDriver:
+    Repository: "https://github.com/intel/SGXDataCenterAttestationPrimitives.git"
+    Branch:     "DCAP_1.11 && cp -r driver/linux/* ."

--- a/Curated-Apps/util/constants.py
+++ b/Curated-Apps/util/constants.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: LGPL-3.0-or-later
+# Copyright (C) 2022 Intel Corporation
+
+title_height = 3
+screen_height = 35
+screen_width = 120
+user_input_height = 5
+user_input_width = screen_width
+user_input_start_y = screen_height - user_input_height
+num_sub_titles = 2
+title_width = screen_width
+sub_title_width = title_width / num_sub_titles
+user_console_height = guide_win_height = screen_height - user_input_height - title_height
+user_console_width = int(screen_width/2) - 3
+guide_win_height = screen_height - user_input_height - title_height
+guide_win_width = int(screen_width/2) - 2
+line_offset = 2
+partition_height = 20
+partition_width = 1
+partition_y = 7
+
+color_set = '::reverse'
+
+test_image_mssg = ('Your test GSC image is being generated. This image is not supposed to be'
+                   ' used in production \n\n')
+
+test_run_instr = ('Run the {} docker image in an Azure Confidential Compute'
+                  ' instance using the below command.\n\n'
+                  'Host networking (--net=host) is optional\n\n{}\n\n'
+                  'Above command is saved to command.txt as well.'
+                  ' Press any key to exit the app')
+test_run_cmd = ('$ docker run --net=host --device=/dev/sgx/enclave -it {}')
+image_not_found_warn = ('Warning: Cannot find application Docker image `{}`.\n'
+                        'Fetching from Docker Hub ...\n\n')
+log_progress = 'You may monitor {} for detailed progress\n\n'
+title = "Curate a Gramine Shielded Container (GSC) image"
+
+user_win_title = 'User Agent'
+help_win_title = 'Commentary'
+
+introduction = ['This application will provide step-by-step guidance for creating your own custom'
+                ' containers protected by Gramine. The commentary window to the right will provide'
+                ' more context for each of the steps.', 'Do not resize this terminal window.',
+                'Press CTRL+G to get started!']
+
+index = ['The target deployment environment is assumed to be an Azure Confidential compute'
+         ' instance.','Following stages are involved in the GSC image curation:',
+         '1. Distro selection',
+         '2. Command-line arguments',
+         '3. Environment variables',
+         '4. Encrypted files and key provisioning',
+         '5. Remote Attestation',
+         '6. Enclave signing',
+         '7. Generation of the final curated images',
+         '8. Generation of docker run commands']
+
+distro_prompt = ['>> Distro Selection:', 'Provide the distro of your base image',
+                 '- Press 1 for Ubuntu 18.04',
+                 '- Press 2 for Ubuntu 20.04',
+                 '- Press 3 for Debian 10',
+                 '- Press 4 for Debian 11',
+                 'Any other option or no input will default to Ubuntu 18.04.',
+                 'Press CTRL+G when done.']
+distro_help = ['Tested distros are Ubuntu 18.04 and Ubuntu 20.04']
+key_prompt = ['>> Enclave signing:' ,
+              '- Please provide path to your enclave signing key in the blue box, OR',
+              '- Type test to generate a test signing key',
+              'Press CTRL+G when done']
+signing_key_help = ['SGX requires RSA 3072 keys with public exponent equal to 3. You can generate'
+                    ' a signing key protected by a test passphrase using below command:',
+                    'openssl genrsa -3 -aes128 -passout pass:test@123 -out enclave-key.pem 3072'
+                    + color_set]
+verifier_build_messg = 'Building the RA-TLS Verifier image, this might take couple of minutes'
+verifier_log_help = 'You may monitor verifier/{} for progress'
+attestation_prompt = ['>> Remote Attestation:' , 'To enable remote attestation using Azure DCAP'
+                      ' client libs, use another terminal to copy the ca.crt, server.crt, and'
+                      ' server.key certificates to Curated-Apps/verifier/ssl directory',
+                      'NOTE: Encrypted Filesystem of Gramine requires Attestation to provision'
+                      ' a decryption key for encrypted files.',
+                      '- Type done when ready, OR',
+                      '- Type test to create test certificates, OR',
+                      '- No input (blank) to skip attestation',
+                      'Press CTRL+G when done']
+attestation_help = ['This step enables the enclave to communicate to a remote verifier over'
+                    ' an Remote Attestation TLS (RA-TLS) link. This remote verifier uses Azure'
+                    ' DCAP client libs to verify the Quote supplied by the enclave. RA-TLS'
+                    ' attestation flow requires you to provide a set of certificates and keys to'
+                    ' enable the attestation flow. The CA certificate will be used to TLS'
+                    ' authenticate the verifier during the RA-TLS flow. A test sample set of'
+                    ' RA-TLS keys and certs are provided here:',
+                    'https://github.com/gramineproject/contrib/tree/master/Examples/aks-attestation/ssl',
+                    'For further reading - ',
+                    'https://gramine.readthedocs.io/en/stable/attestation.html']
+
+encrypted_files_prompt = ['>> Encrypted files and key provisioning:', 'Please provide path of'
+                          ' these files relative to the working directory:', '1. Encrypted files'
+                          ' in the base image used by the application, if any.', '2. Files created'
+                          ' at runtime, if any.', 'Accepted format: `file_path1:file_path2`',
+                          'e.g. for workloads/pytorch/base_image_helper/Dockerfile based image,'
+                          ' the encrypted files input would be --> ',
+                          'classes.txt:input.jpg:alexnet-pretrained.pt:result.txt' + color_set,
+                          'Press CTRL+G when done']
+encypted_files_help = ["Gramine's Encrypted FS feature supports transparently decrypting data"
+                       ' using the encryption key that will be provisioned after successful'
+                       ' attestation.']
+encryption_key_prompt = ('Please provide the path to the key used for the encryption. Press CTRL+G'
+                         ' when done')
+arg_input = ['>> Command-line arguments:', 'Specify docker command-line arguments here in a single'
+             ' string. For example, if your docker runtime is ', 'docker run <image_name> arg1'
+             ' arg2' + color_set, 'then the arguments that need to be provided here are', 'arg1'
+             ' arg2' + color_set, 'Press CTRL+G when done']
+arg_help = ['Allowing an attacker to control executable arguments can break the security of the'
+            ' resulting enclave. Gramine will ignore any arguments provided at docker run-time,'
+            ' so ensure those are provided here now']
+
+env_input = ['>> Environment variables:', 'Please specify a list of env variables and respective'
+             ' values in below mentioned format:',
+             '-e ENV_NAME1="value1" -e ENV_NAME2="value2"' + color_set,
+             'Press CTRL+G when done']
+env_help =  ['This step secures the environment variables. Gramine will ignore environment'
+             ' variables specified at runtime, so please ensure you provide those here.'
+             ' By default Gramine will add all the environment variables set in the base'
+             ' docker image.']
+wait_message = ['Image Creation:', 'Your Gramine Shielded Container image is being created.'
+                ' This might take a few minutes.']
+system_config_message = ['System config by default is assumed to be an Azure Confidential compute'
+                         ' instance.']
+run_command_no_att = '$ docker run {} --device=/dev/sgx/enclave -it {}'
+run_with_debug = 'python3 curate.py {} {} debug' + color_set
+extra_debug_instr = ("It's also possible that you may run into issues resulting from lack of"
+                     ' sufficient enclave memory pages, or insufficient number of threads.'
+                     ' The {}.manifest can be modified to change the defaults.')
+app_exit_messg = 'Press CTRL+G to exit the application'
+debug_run_messg = ('In the event of failures during runtime, run with debug flag (if not already)'
+                   ' to get more information, as shown below:')
+commands_file = 'commands.txt'
+image_ready_messg  = ('The curated GSC image {} is ready, please follow the instructions in the'
+                      ' below file to run your image(s).')
+image_ready_messg_att = ('The curated GSC image , and the remote attestation verifier'
+                         ' image is ready, You can run the images using the instructions provided'
+                         ' in the below file.')
+workload_run = ('$ docker run {} --device=/dev/sgx/enclave -e SECRET_PROVISION_SERVERS={}'
+                ' -v /var/run/aesmd/aesm.socket:/var/run/aesmd/aesm.socket -it {}')
+enc_keys_mount = '-v {}:/keys'
+enc_key_path = '/keys/{}'
+ssl_folder_path_on_host = 'verifier/ssl_common'
+verifier_cert_mount = '-v {}:/ra-tls-secret-prov/ssl'
+debug_enclave_env_verifier = (' -e RA_TLS_ALLOW_DEBUG_ENCLAVE_INSECURE=1 -e'
+                              ' RA_TLS_ALLOW_OUTDATED_TCB_INSECURE=1 ')
+azure_warning = ['Warning: You are building'
+                 ' these images on a non Azure Confidential Compute instance' + color_set,
+                 'Please ensure you run the final images on an Azure VM or in the AKS cluster only'
+                 ,'Press CTRL+G to continue']
+azure_help = ['The target deployment environment is assumed to be an Azure Confidential compute'
+              ' instance.']
+verifier_log_file = 'verifier.log'
+file_not_found_error = 'Error: {} file does not exist.'
+CTRL_G = 7

--- a/Curated-Apps/util/curation_script.sh
+++ b/Curated-Apps/util/curation_script.sh
@@ -1,0 +1,241 @@
+#!/bin/bash
+# SPDX-License-Identifier: LGPL-3.0-or-later
+# Copyright (C) 2022 Intel Corporation
+
+# This script takes input from curate.py and creates GSC image.
+# The script can be called either for creating a non-production test image or a custom GSC image.
+#
+# The test image is created when user runs `python ./curate.py <workload type> <user_image> test`
+# command. The image hence created will be signed with a test enclave key, and will not support
+# attestation.
+#
+# In case of test image, the script takes 7 input parameters, whereas in case of custom image 13
+# parameters are passed from curate.py.
+#
+# curate.py calls this script after taking all the user inputs. This script does not interact with
+# user, it just processes the input received from curate.py and produces the final GSC image.
+
+# The input parameters in sequence are below:
+# -- arg1    : workload type e.g. redis or pytorch
+# -- arg2    : base_image_name e.g. name of the base image to be graminized
+# -- arg3    : distro e.g. ubuntu:18.04 or ubuntu:20.04
+# -- arg4    : path to the enclave signing key or
+#              'test' string to generate test signing key
+# -- arg5    : string with command-line arguments (hard-coded in Docker image via Gramine manifest)
+# -- arg6    : 'test-image' string to create a non-production GSC image when curate.py is run in
+#            :  test mode
+#            : y or n (attestation required?) in case of custom image creation
+# -- arg7    : y or n (build GSC with debug?)
+# -- arg8    : verifier's ca certificate path
+# -- arg9    : y or n (environment variables available?)
+# -- arg10   : Actual environment variable string
+# -- arg11   : y or n (encrypted files as part of base image?)
+# -- arg12   : Path to the encrypted files in the image
+# -- arg13   : Passphrase to the enclave signing key (if applicable)
+
+echo printing args $0 $@
+
+start=$1
+wrapper_dockerfile=$start'-gsc.dockerfile'
+app_image_manifest=$start'.manifest'
+
+CUR_DIR=$(pwd)
+WORKLOAD_DIR=$CUR_DIR'/workloads/'$start
+cd $WORKLOAD_DIR
+mkdir $CUR_DIR'/test' >/dev/null 2>&1
+
+cp $wrapper_dockerfile'.template' $wrapper_dockerfile
+cp $app_image_manifest'.template' $app_image_manifest
+
+base_image="$2"
+distro="$3"
+# Set base image name in the dockerfile
+sed -i 's|^From <base_image_name>$|From '$base_image'|' $wrapper_dockerfile
+
+if [[ "$base_image" == *":"* ]]; then
+    app_image_x=$(echo $base_image | sed "s/:/_x:/")
+else
+    app_image_x="${base_image}_x"
+fi
+
+create_base_wrapper_image () {
+    docker rmi -f $app_image_x >/dev/null 2>&1
+    docker build -f $wrapper_dockerfile -t $app_image_x .
+}
+
+add_encrypted_files_to_manifest(){
+    IFS=':' # Setting colon as delimiter
+    read -a ef_files_list <<<"$1"
+    unset IFS
+    echo '' >> $app_image_manifest
+    echo '# User Provided Encrypted files' >> $app_image_manifest
+    echo 'fs.mounts = [' >> $app_image_manifest
+    workdir_base_image="$(docker image inspect "$base_image" | jq '.[].Config.WorkingDir')"
+    workdir_base_image=`sed -e 's/^"//' -e 's/"$//' <<<"$workdir_base_image"`
+    for i in "${ef_files_list[@]}"
+    do
+        encrypted_files_string='  { path = "'$workdir_base_image'/'$i'", uri = "file:'$i'", '
+        encrypted_files_string+='type = "encrypted" },'
+        echo "$encrypted_files_string" >> $app_image_manifest
+    done
+    echo "]" >> $app_image_manifest
+}
+
+create_gsc_image () {
+    echo
+    cd $CUR_DIR
+    rm -rf gsc >/dev/null 2>&1
+    git clone --depth 1 https://github.com/gramineproject/gsc.git
+    cp $signing_key_path gsc/enclave-key.pem
+
+    cd gsc
+    cp ../util/config.yaml.template config.yaml
+    sed -i 's|ubuntu:.*|'$distro'"|' config.yaml
+
+    # Delete already existing GSC image for the base image
+    docker rmi -f gsc-$base_image >/dev/null 2>&1
+    docker rmi -f gsc-$base_image-unsigned >/dev/null 2>&1
+
+    if [ "$1" = "y" ]; then
+        ./gsc build -d $app_image_x  $WORKLOAD_DIR/$app_image_manifest
+    else
+        ./gsc build $app_image_x $WORKLOAD_DIR/$app_image_manifest
+    fi
+
+    echo
+    docker tag gsc-$app_image_x-unsigned gsc-$base_image-unsigned
+    password_arg=''
+    if [[ "$signing_input" != "test" && "$2" != "" ]]; then
+        password_arg="-p $2"
+    fi
+    ./gsc sign-image $base_image enclave-key.pem $password_arg
+    docker rmi -f gsc-$base_image-unsigned >/dev/null 2>&1
+    docker rmi gsc-$app_image_x-unsigned
+    docker rmi -f $app_image_x >/dev/null 2>&1
+    ./gsc info-image gsc-$base_image
+
+    cd ../
+    rm -rf gsc >/dev/null 2>&1
+    rm -rf $CUR_DIR'/test' >/dev/null 2>&1
+}
+
+fetch_base_image_config () {
+    base_image_config="$(docker image inspect "$base_image" | jq '.[].Config.'$1'')"
+    if [[ "$base_image_config" = "null" || "$base_image_config" = "Null" ||
+          "$base_image_config" = "NULL" ]]; then
+        config_string=''
+    else
+        base_image_config=$(echo $base_image_config | sed 's/[][]//g')
+        config_string=$(echo $base_image_config | sed 's/"\s*,\s*"/" "/g')
+    fi
+    echo $config_string
+}
+
+# Signing key
+echo ""
+read -r signing_input signing_key_path <<<$(echo "$4 $4")
+if [ "$signing_input" = "test" ]; then
+    echo 'Generating signing key'
+    openssl genrsa -3 -out $CUR_DIR'/test/enclave-key.pem' 3072
+    signing_key_path=$CUR_DIR'/test/enclave-key.pem'
+    grep -qxF 'sgx.file_check_policy = "allow_all_but_log"' $app_image_manifest ||
+     echo 'sgx.file_check_policy = "allow_all_but_log"' >> $app_image_manifest
+fi
+
+# Command-line arguments:
+args=$5
+if [[ "$start" = "redis" ]]; then
+    args+=" --protected-mode no --save ''"
+fi
+
+# Forming a complete binary string
+entrypoint_string=$(fetch_base_image_config "Entrypoint")
+cmd_string=$(fetch_base_image_config "Cmd")
+complete_binary_cmd="$entrypoint_string "
+
+if [[ "$args" = "" ]]; then
+    complete_binary_cmd+=$cmd_string
+else
+    complete_binary_cmd+=$args
+fi
+
+# Creating entrypoint script file
+entrypoint_script=entry_script_$start.sh
+rm -f $entrypoint_script >/dev/null 2>&1
+touch $entrypoint_script
+
+# Copying the complete binary string to the entrypoint script file
+echo '#!/bin/bash' >> $entrypoint_script
+echo '' >> $entrypoint_script
+echo $complete_binary_cmd >> $entrypoint_script
+
+# Test image creation
+if [ "$6" = "test-image" ]; then
+    grep -qxF 'sgx.file_check_policy = "allow_all_but_log"' $app_image_manifest ||
+     echo 'sgx.file_check_policy = "allow_all_but_log"' >> $app_image_manifest
+
+    if [[ "$start" = "pytorch" ]]; then
+        encrypted_files='classes.txt:input.jpg:alexnet-pretrained.pt:result.txt'
+        add_encrypted_files_to_manifest $encrypted_files
+        var=$(xxd -p ../pytorch/base_image_helper/encryption_key)
+        echo 'fs.insecure__keys.default = "'$var'"' >> $app_image_manifest
+    fi
+
+    create_base_wrapper_image
+    create_gsc_image $7
+    exit 1
+fi
+
+# Get Attestation Input
+attestation_required=$6
+if [ "$attestation_required" = "y" ]; then
+    ca_cert_path=$8
+    cp $CUR_DIR/$ca_cert_path ca.crt
+    sed -i 's|.*ca.crt.*|COPY ca.crt /ca.crt|' $wrapper_dockerfile
+    echo '' >> $app_image_manifest
+    echo '# Attestation related entries' >> $app_image_manifest
+    echo 'sgx.remote_attestation = "dcap"' >> $app_image_manifest
+    echo 'loader.env.LD_PRELOAD = ' \
+    '"/gramine/meson_build_output/lib/x86_64-linux-gnu/libsecret_prov_attest.so"' >> \
+    $app_image_manifest
+    echo 'loader.env.SECRET_PROVISION_SERVERS = { passthrough = true }' >> $app_image_manifest
+    echo 'loader.env.SECRET_PROVISION_CONSTRUCTOR = "1"' >> $app_image_manifest
+    echo 'loader.env.SECRET_PROVISION_CA_CHAIN_PATH = "/ca.crt"' >> $app_image_manifest
+    echo '# loader.env.SECRET_PROVISION_SET_KEY = "default"' >> $app_image_manifest
+    echo '' >> $app_image_manifest
+fi
+
+# Environment Variables:
+env_required=$9
+if [ "$env_required" = "y" ]; then
+    envs=${10}
+    echo '' >> $app_image_manifest
+    echo '# User Provided Environment Variables' >> $app_image_manifest
+
+    re_pattern='-e[[:space:]]*([^[:space:].=]*="[^"]*")'
+    while [[ $envs =~ $re_pattern ]]; do
+        echo "loader.env.${BASH_REMATCH[1]}" >> $app_image_manifest
+        envs=${envs#*${BASH_REMATCH[1]}}
+    done
+    echo ""
+fi
+
+# Encrypted Files Section
+encrypted_files_required=${11}
+if [ "$encrypted_files_required" = "y" ]; then
+    ef_files=${12}
+    add_encrypted_files_to_manifest ${12}
+    sed -i 's|.*SECRET_PROVISION_SET_KEY.*|loader.env.SECRET_PROVISION_SET_KEY = "default"|' \
+    $app_image_manifest
+fi
+
+echo ""
+if [[ "$7" = "y" && "$signing_input" != "test" && "$start" = "redis" ]]; then
+    echo 'loader.pal_internal_mem_size = "192M"' >> $app_image_manifest
+fi
+
+create_base_wrapper_image
+if [ "$attestation_required" = "y" ]; then
+    rm ca.crt
+fi
+create_gsc_image $7 ${13}

--- a/Curated-Apps/verifier/.gitignore
+++ b/Curated-Apps/verifier/.gitignore
@@ -1,0 +1,6 @@
+/*.log
+/ca.crt
+/ssl/*
+!/ssl/.gitkeep
+/ssl_common/*
+/verifier.dockerfile

--- a/Curated-Apps/verifier/helper.sh
+++ b/Curated-Apps/verifier/helper.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# SPDX-License-Identifier: LGPL-3.0-or-later
+# Copyright (C) 2022 Intel Corporation
+
+# This script takes input from curate.py and creates verifier image.
+# The script is called only when attestation is required by the user.
+
+# The input parameters in sequence are below:
+# -- arg1    : 'done' means user provided his own certs in verifier/ssl directory, else the default
+#               non-production ready certs will be used. The certs are finally copied to ssl_common
+#               directory for future use by GSC image and the verifier image.
+# -- arg2    :  encryption key path. When this variable is set, then `CMD ["key-path"]` will be
+#               appended to verifier.dockerfile
+echo printing args $0 $@
+
+rm -rf  ssl_common >/dev/null 2>&1
+mkdir -p ssl_common
+
+if [ "$1" = "done" ]; then
+    cd ssl
+    cp ca.crt server.crt server.key ../ssl_common
+    cd ..
+else
+    rm -rf gramine >/dev/null 2>&1
+    git clone --depth 1 --branch v1.3 https://github.com/gramineproject/gramine.git
+
+    cd gramine/CI-Examples/ra-tls-secret-prov
+    make clean && make ssl/server.crt >/dev/null 2>&1
+    cd ssl
+    cp ca.crt server.crt server.key ../../../../ssl_common
+    cd ../../../../
+    rm -rf gramine >/dev/null 2>&1
+fi
+
+cp verifier.dockerfile.template verifier.dockerfile
+
+args=''
+# Use `secret_prov_pf` if base image has encrypted files
+if [ "$2" = "y" ]; then
+    sed -i 's|secret_prov_minimal|secret_prov_pf|g' verifier.dockerfile
+    args="--build-arg server_dcap_pf=y"
+fi
+
+if [ ! -z "$3" ]; then
+    echo 'CMD ["'$3'"]' >> verifier.dockerfile
+fi
+
+docker rmi -f verifier_image >/dev/null 2>&1
+docker build -f verifier.dockerfile -t verifier $args .

--- a/Curated-Apps/verifier/verifier.dockerfile.template
+++ b/Curated-Apps/verifier/verifier.dockerfile.template
@@ -1,0 +1,45 @@
+FROM ubuntu:18.04
+
+RUN apt-get update \
+    && env DEBIAN_FRONTEND=noninteractive apt-get install -y \
+    build-essential \
+    curl \
+    git \
+    gnupg2 \
+    wget
+
+# Installing Azure DCAP Quote Provider Library (az-dcap-client).
+# Here, the version of az-dcap-client should be in sync with the az-dcap-client
+# version used for quote generation. User can replace the below package with the
+# latest package.
+RUN wget https://packages.microsoft.com/ubuntu/18.04/prod/pool/main/a/az-dcap-client/az-dcap-client_1.10_amd64.deb \
+ && dpkg -i az-dcap-client_1.10_amd64.deb
+
+RUN echo 'deb [arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu bionic main' \
+    > /etc/apt/sources.list.d/intel-sgx.list \
+    && wget https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key \
+    && apt-key add intel-sgx-deb.key
+
+RUN curl -fsSLo /usr/share/keyrings/gramine-keyring.gpg https://packages.gramineproject.io/gramine-keyring.gpg
+RUN echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/gramine-keyring.gpg] https://packages.gramineproject.io/ stable main' | tee /etc/apt/sources.list.d/gramine.list
+RUN apt-get update
+RUN apt-get install -y gramine-dcap
+
+RUN git clone --depth 1 --branch v1.3 https://github.com/gramineproject/gramine.git
+
+ARG server_dcap_pf="n"
+RUN if [ $server_dcap_pf="y" ]; then \
+        sed -i "s|verify_measurements_callback,|NULL,|g" \
+        "gramine/CI-Examples/ra-tls-secret-prov/secret_prov_pf/server.c"; \
+    fi
+
+RUN mkdir -p /ra-tls-secret-prov/secret_prov_minimal
+RUN cd gramine/CI-Examples/ra-tls-secret-prov/ \
+    && make clean && make dcap >/dev/null 2>&1 \
+    && cp secret_prov_minimal/server_dcap /ra-tls-secret-prov/secret_prov_minimal/
+
+RUN rm -rf gramine >/dev/null 2>&1
+
+WORKDIR /ra-tls-secret-prov/secret_prov_minimal
+
+ENTRYPOINT ["./server_dcap"]

--- a/Curated-Apps/workloads/pytorch/.gitignore
+++ b/Curated-Apps/workloads/pytorch/.gitignore
@@ -1,0 +1,4 @@
+/*.log
+/entry_script_pytorch.sh
+/pytorch-gsc.dockerfile
+/pytorch.manifest

--- a/Curated-Apps/workloads/pytorch/README.md
+++ b/Curated-Apps/workloads/pytorch/README.md
@@ -1,0 +1,59 @@
+# Gramine Curated PyTorch
+In the following two sections, we explain how a Docker image for the protected PyTorch version can
+be built and how the image can be executed.
+[Prerequisites](https://github.com/gramineproject/contrib/tree/master/Curated-Apps/README.md) for
+both the phases are assumed to be met.
+
+## Build a confidential compute image for PyTorch
+Execute the below commands on the VM.
+
+1. Clone the Gramine Contrib repository:
+
+       $ git clone --depth 1 https://github.com/gramineproject/contrib.git
+
+2. Move to the Curated-Apps folder:
+
+       $ cd contrib/Curated-Apps
+
+3. User is expected to first have a base image `<base_image_with_pytorch>` ready with PyTorch and
+   the necessary application files built into this image. The current directory contains sample
+   dockerfiles and instructions to create a test PyTorch base image. This base image is then passed
+   to the curation application `curate.py` as shown below.
+
+4. To generate a preconfigured non-production test confidential compute image for PyTorch,  follow
+   the below steps:
+   1. Generate a sample PyTorch application image `pytorch-encrypted`:
+
+          $ /bin/bash workloads/pytorch/base_image_helper/helper.sh
+
+   2. Generate the test confidential compute image based on the `pytorch-encrypted` image  as shown 
+      below:
+
+          $ python3 ./curate.py pytorch pytorch-encrypted test
+
+5. To generate a custom confidential compute image based on a user-provided PyTorch image, execute
+   the following to launch an interactive setup script:
+
+       $ python3 ./curate.py pytorch <base_image_with_pytorch>
+
+## Run the confidential compute image for PyTorch
+
+- This example was tested on a Standard_DC8s_v3 Azure VM.
+- Follow the output of the `curate.py` script to run the generated Docker image(s).
+
+## Contents
+This sub-directory contains artifacts which help in creating curated GSC PyTorch image, as explained
+below:
+
+    .
+    |-- pytorch-gsc.dockerfile.template   # Template used by `curation_script.sh` to create a
+    |                                       wrapper dockerfile `pytorch-gsc.dockerfile` that
+    |                                       includes user-provided inputs such as `ca.cert`
+    |                                       file and command-line arguments into the graminized
+    |                                       PyTorch image.
+    |-- pytorch.manifest.template         # Template used by `curation_script.sh` to create a
+    |                                       user manifest file (with basic set of values defined
+    |                                       for graminizing PyTorch images), that will be passed to
+    |                                       GSC.
+    |-- base_image_helper/                # `base_image_helper` directory contains artifacts which
+    |                                       helps in generating a base image with encrypted files.

--- a/Curated-Apps/workloads/pytorch/base_image_helper/.gitignore
+++ b/Curated-Apps/workloads/pytorch/base_image_helper/.gitignore
@@ -1,0 +1,5 @@
+/alexnet-pretrained.pt
+/classes.txt
+/input.jpg
+/pytorchexample.py
+/encryption_key

--- a/Curated-Apps/workloads/pytorch/base_image_helper/Dockerfile
+++ b/Curated-Apps/workloads/pytorch/base_image_helper/Dockerfile
@@ -1,0 +1,7 @@
+FROM pytorch/pytorch:latest
+COPY input.jpg ./
+COPY classes.txt ./
+COPY alexnet-pretrained.pt ./
+COPY pytorchexample.py ./
+
+ENTRYPOINT ["python3", "pytorchexample.py"]

--- a/Curated-Apps/workloads/pytorch/base_image_helper/README.md
+++ b/Curated-Apps/workloads/pytorch/base_image_helper/README.md
@@ -1,0 +1,30 @@
+This directory contains steps and artifacts to create a docker image with encrypted files.
+
+# Prerequisites
+
+- Please install [prerequisites](https://github.com/gramineproject/examples/tree/master/pytorch#pre-requisites)
+  on your machine.
+- File Encryption is done using `gramine-sgx-pf-crypt` tool which is part of
+  [Gramine installation](https://gramine.readthedocs.io/en/latest/quickstart.html#install-gramine).
+
+# Base docker image creation
+
+We will use PyTorch example available [here](https://github.com/gramineproject/examples/blob/master/pytorch/)
+to demonstrate the base image creation with encrypted files.
+
+- Execute `bash ./helper.sh` command to encrypt the files and create base image with
+  encrypted files.
+
+Please refer to `Curated-Apps/workloads/pytorch/README.md` to curate the image created in above
+steps with GSC.
+
+# Retrieve and decrypt results
+
+Results are generated in `/workspace/result.txt` within container in encrypted form after running
+the curated GSC image. User need to copy results from container to local machine and decrypt using
+below commands
+
+- Execute `docker cp <container id or name>:/workspace/result.txt .` to fetch results from docker
+  container to local machine.
+- Execute `gramine-sgx-pf-crypt decrypt -w encryption_key -i result.txt -o result_plaintext.txt` to
+  decrypt the results. Make sure `encryption_key` path in decryption command is correct.

--- a/Curated-Apps/workloads/pytorch/base_image_helper/helper.sh
+++ b/Curated-Apps/workloads/pytorch/base_image_helper/helper.sh
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: LGPL-3.0-or-later
+# Copyright (C) 2022 Intel Corporation
+
+# exit when any command fails
+set -e
+
+CUR_DIR=$(pwd)
+MY_PATH=$(dirname "$0")
+cd $MY_PATH
+
+image_name='pytorch-encrypted'
+rm -rf examples
+git clone --depth 1 https://github.com/gramineproject/examples.git
+cd examples/pytorch
+
+# Download and save the pre-trained model
+python3 download-pretrained-model.py
+cd ../../
+
+dd if=/dev/urandom bs=16 count=1 > encryption_key
+
+gramine-sgx-pf-crypt encrypt -w encryption_key -i examples/pytorch/input.jpg -o input.jpg
+gramine-sgx-pf-crypt encrypt -w encryption_key -i examples/pytorch/classes.txt -o classes.txt
+gramine-sgx-pf-crypt encrypt -w encryption_key -i examples/pytorch/alexnet-pretrained.pt -o \
+alexnet-pretrained.pt
+
+mv examples/pytorch/pytorchexample.py ./
+
+# Build pytorch base image
+docker rmi -f $image_name >/dev/null 2>&1
+docker build -t $image_name .
+
+rm -rf examples
+rm pytorchexample.py input.jpg classes.txt alexnet-pretrained.pt
+cd $CUR_DIR
+
+echo -e '\n\nCreated base image `'$image_name'`.'
+echo -e 'Please refer to `Curated-Apps/workloads/pytorch/README.md` to curate the above image' \
+' with GSC.\n'

--- a/Curated-Apps/workloads/pytorch/pytorch-gsc.dockerfile.template
+++ b/Curated-Apps/workloads/pytorch/pytorch-gsc.dockerfile.template
@@ -1,0 +1,12 @@
+# This template is used by `curation_script.sh` to create a wrapper dockerfile
+# `pytorch-gsc.dockerfile` that includes user provided inputs such as `ca.cert`
+# file and run-time arguments into the graminized PyTorch image.
+
+# The curation script fills the <base_image_name> during curation.
+From <base_image_name>
+
+# COPY ca.crt /ca.crt
+
+# These two lines are required to incorporate command-line arguments with the image entrypoint and cmd
+COPY entry_script_pytorch.sh /usr/local/bin/entry_script_pytorch.sh
+ENTRYPOINT ["/bin/bash", "/usr/local/bin/entry_script_pytorch.sh"]

--- a/Curated-Apps/workloads/pytorch/pytorch.manifest.template
+++ b/Curated-Apps/workloads/pytorch/pytorch.manifest.template
@@ -1,0 +1,14 @@
+# This file has basic set of values defined for graminizing PyTorch images. This manifest template
+# is used by `curation_script.sh` to create the user manifest file that will be passed to GSC.
+
+sgx.nonpie_binary = true
+sgx.enclave_size = "4G"
+sgx.thread_num = 128
+loader.pal_internal_mem_size = "128M"
+
+# This is required to run workload as non-root user, any random number works except `0` which
+# is for root.
+loader.uid=999
+loader.gid=999
+
+sys.enable_extra_runtime_domain_names_conf = true

--- a/Curated-Apps/workloads/redis/.gitignore
+++ b/Curated-Apps/workloads/redis/.gitignore
@@ -1,0 +1,4 @@
+/*.log
+/redis-gsc.dockerfile
+/redis.manifest
+/entry_script_redis.sh

--- a/Curated-Apps/workloads/redis/README.md
+++ b/Curated-Apps/workloads/redis/README.md
@@ -1,0 +1,45 @@
+# Gramine Curated Redis
+In the following two sections, we explain how a Docker image for the protected Redis version can be
+built and how the image can be executed.
+[Prerequisites](https://github.com/gramineproject/contrib/tree/master/Curated-Apps/README.md) for
+both the phases are assumed to be met.
+
+## Build a confidential compute image for Redis
+Execute the below commands on the VM.
+
+1. Clone the Gramine Contrib repository:
+
+       $ git clone --depth 1 https://github.com/gramineproject/contrib.git
+
+2. Move to the Curated-Apps folder:
+
+       $ cd contrib/Curated-Apps
+
+3. To generate a preconfigured confidential compute image for Redis, execute the following script:
+
+       $ python3 ./curate.py redis redis:7.0.0 test
+
+4. To generate a custom confidential compute image based on a user-provided Redis image, execute
+   the following to launch an interactive setup script:
+
+       $ python3 ./curate.py redis <your_image>
+
+## Run the confidential compute image for Redis
+
+- This example was tested on a Standard_DC2s_v2 Azure VM.
+- Follow the output of the image build script `curate.py` to run the generated Docker image.
+
+## Contents
+This sub-directory contains artifacts which help in creating curated GSC Redis image, as explained
+below:
+
+    .
+    |-- redis-gsc.dockerfile.template      # Template used by `curation_script.sh` to create a
+    |                                        wrapper dockerfile `redis-gsc.dockerfile` that
+    |                                        includes user-provided inputs such as `ca.cert`
+    |                                        file and command-line arguments into the graminized
+    |                                        Redis image.
+    |-- redis.manifest.template            # Template used by `curation_script.sh` to create a
+    |                                        user manifest file (with basic set of values defined
+    |                                        for graminizing Redis images), that will be passed to
+    |                                        GSC.

--- a/Curated-Apps/workloads/redis/redis-gsc.dockerfile.template
+++ b/Curated-Apps/workloads/redis/redis-gsc.dockerfile.template
@@ -1,0 +1,12 @@
+# This template is used by `curation_script.sh` to create a wrapper dockerfile
+# `redis-gsc.dockerfile` that includes user provided inputs such as `ca.cert`
+# file and run-time arguments into the graminized Redis image.
+
+# The curation script fills the <base_image_name> during curation.
+From <base_image_name>
+
+# COPY ca.crt /ca.crt
+
+# These two lines are required to incorporate command-line arguments with the image entrypoint and cmd
+COPY entry_script_redis.sh /usr/local/bin/entry_script_redis.sh
+ENTRYPOINT ["/bin/bash", "/usr/local/bin/entry_script_redis.sh"]

--- a/Curated-Apps/workloads/redis/redis.manifest.template
+++ b/Curated-Apps/workloads/redis/redis.manifest.template
@@ -1,0 +1,13 @@
+# This file has basic set of values defined for graminizing Redis images. This manifest template
+# is used by `curation_script.sh` to create the user manifest file that will be passed to GSC.
+
+sgx.nonpie_binary = true
+sgx.enclave_size = "1024M"
+sgx.thread_num = 8
+
+# This is required to run workload as non-root user, any random number works except `0` which
+# is for root.
+loader.uid=999
+loader.gid=999
+
+sys.enable_extra_runtime_domain_names_conf = true


### PR DESCRIPTION
Signed-off-by: aneessahib <anees.a.sahib@intel.com>
This application will provide step-by-step guidance in creating your own custom containers protected by Gramine. 
The target deployment environment is assumed to be an Azure Confidential compute instance with out of tree DCAP driver. Following stages are involved in the GSC image curation:
- Distro Selection
- Enclave Signing Key
- Attestation
- Secret Provisioning
- Encrypted Files
- Environment Variables
- Runtime Arguments
- Execution & Debug

To test, execute in the below order

`$ sudo apt-get install jq`
`$ sudo apt-get install docker.io python3 python3-pip`
`$ pip3 install docker jinja2 toml pyyaml`
`$ python3 curate.py redis redis:7.0.0`


<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/contrib/7)
<!-- Reviewable:end -->
