### PR TITLE
Reverted the commit aa71356 used for workaround the packaging issue

### DIFF
--- a/Curated-Apps/curate.py
+++ b/Curated-Apps/curate.py
@@ -469,7 +469,7 @@ def main(stdscr, argv):
         if len(isv_svn_list) > 0: isv_svn = isv_svn_list[0]
 
         verifier_run_command = (f'Execute below command to start verifier on a trusted system:\n'
-                                f'$ docker run {host_net} --device=/dev/sgx/enclave:/dev/sgx_enclave '
+                                f'$ docker run {host_net} --device=/dev/sgx/enclave '
                                 f'-e RA_TLS_MRENCLAVE={mr_enclave} -e RA_TLS_MRSIGNER={mr_signer} '
                                 f'-e RA_TLS_ISV_PROD_ID={isv_prod_id} -e RA_TLS_ISV_SVN={isv_svn} '
                                 f'{debug_enclave_env_ver_ext}' + verifier_cert_mount_str + ' ' +

--- a/Curated-Apps/util/config.yaml.template
+++ b/Curated-Apps/util/config.yaml.template
@@ -13,7 +13,7 @@ Registry: ""
 # below; typically, you want to keep the default values though
 Gramine:
     Repository: "https://github.com/gramineproject/gramine.git"
-    Branch:     "v1.3"
+    Branch:     "v1.3.1"
 
 # Specify the Intel SGX driver installed on your target machine (more specifically, on the machine
 # where the graminized Docker container will run); Default assumption is DCAP out-of-tree driver,

--- a/Curated-Apps/verifier/helper.sh
+++ b/Curated-Apps/verifier/helper.sh
@@ -22,10 +22,10 @@ if [ "$1" = "done" ]; then
     cd ..
 else
     rm -rf gramine >/dev/null 2>&1
-    git clone --depth 1 --branch v1.3 https://github.com/gramineproject/gramine.git
+    git clone --depth 1 --branch v1.3.1 https://github.com/gramineproject/gramine.git
 
     cd gramine/CI-Examples/ra-tls-secret-prov
-    make clean && make ssl/server.crt >/dev/null 2>&1
+    make clean && make ssl/server.crt
     cd ssl
     cp ca.crt server.crt server.key ../../../../ssl_common
     cd ../../../../

--- a/Curated-Apps/verifier/verifier.dockerfile.template
+++ b/Curated-Apps/verifier/verifier.dockerfile.template
@@ -6,8 +6,7 @@ RUN apt-get update \
     curl \
     git \
     gnupg2 \
-    wget \
-    pkg-config
+    wget
 
 # Installing Azure DCAP Quote Provider Library (az-dcap-client).
 # Here, the version of az-dcap-client should be in sync with the az-dcap-client
@@ -24,11 +23,9 @@ RUN echo 'deb [arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu bio
 RUN curl -fsSLo /usr/share/keyrings/gramine-keyring.gpg https://packages.gramineproject.io/gramine-keyring.gpg
 RUN echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/gramine-keyring.gpg] https://packages.gramineproject.io/ bionic main' | tee /etc/apt/sources.list.d/gramine.list
 RUN apt-get update
-RUN apt-get install -y gramine
-RUN wget http://mirrors.kernel.org/ubuntu/pool/universe/c/cjson/libcjson1_1.7.10-1.1_amd64.deb \
-    && dpkg -i libcjson1_1.7.10-1.1_amd64.deb
+RUN apt-get install -y gramine-dcap
 
-RUN git clone --depth 1 --branch v1.3 https://github.com/gramineproject/gramine.git
+RUN git clone --depth 1 --branch v1.3.1 https://github.com/gramineproject/gramine.git
 
 ARG server_dcap_pf="n"
 RUN if [ $server_dcap_pf="y" ]; then \
@@ -38,7 +35,7 @@ RUN if [ $server_dcap_pf="y" ]; then \
 
 RUN mkdir -p /ra-tls-secret-prov/secret_prov_minimal
 RUN cd gramine/CI-Examples/ra-tls-secret-prov/ \
-    && make clean && make dcap >/dev/null 2>&1 \
+    && make clean && make dcap \
     && cp secret_prov_minimal/server_dcap /ra-tls-secret-prov/secret_prov_minimal/
 
 RUN rm -rf gramine >/dev/null 2>&1


### PR DESCRIPTION
Reverted the commit aa71356 used for workaround the packaging issue with gramine v1.3, enabled build logs which were hidden before and updated the latest gramine tag 1.3.1.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/contrib/10)
<!-- Reviewable:end -->
