### PR TITLE
[Curated-Apps] Add user inputs for additional docker run flags

### DIFF
--- a/Curated-Apps/curate.py
+++ b/Curated-Apps/curate.py
@@ -354,7 +354,11 @@ def main(stdscr, argv):
     if envs:
         env_required = 'y'
 
-    # 4. Provide encrypted files and key provisioning
+    # 4. Provide additional docker run flags
+    update_user_and_commentary_win_array(user_console, guide_win, flags_input, flags_help)
+    flags = update_user_input()
+
+    # 5. Provide encrypted files and key provisioning
     ef_required = 'n'
     encryption_key = ''
     enc_key_path_in_verifier = ''
@@ -370,7 +374,7 @@ def main(stdscr, argv):
         enc_key_path_in_verifier = enc_key_path.format(encryption_key_name)
         ef_required = 'y'
 
-    # 5. Remote Attestation with RA-TLS
+    # 6. Remote Attestation with RA-TLS
     ca_cert_path = ''
     config = ''
     verifier_server = '<verifier-dns-name:port>'
@@ -399,7 +403,7 @@ def main(stdscr, argv):
 
         break
 
-    # 6. Obtain enclave signing key
+    # 7. Obtain enclave signing key
     update_user_and_commentary_win_array(user_console, guide_win, key_prompt, signing_key_help)
     key_path = get_enclave_signing_input(user_console, guide_win)
     passphrase = ''
@@ -413,7 +417,7 @@ def main(stdscr, argv):
                       '                   Press CTRL+G to continue')
         passphrase = update_user_input(secure=True)
 
-    # 7. Generation of the final curated images
+    # 8. Generation of the final curated images
     if attestation_required == 'y':
         os.chdir('verifier')
         verifier_log_file_pointer = open(verifier_log_file, 'w')
@@ -435,7 +439,9 @@ def main(stdscr, argv):
     image = gsc_app_image
     check_image_creation_success(user_console, docker_socket, image, log_file)
 
-    # 8. Generation of docker run commands
+    # 9. Generation of docker run commands
+    if host_net and host_net not in flags:
+        flags = flags + " " + host_net
     commands_fp = open(commands_file, 'w')
     if attestation_required == 'y':
         debug_enclave_env_ver_ext = ''
@@ -484,9 +490,9 @@ def main(stdscr, argv):
         run_command = (f'{verifier_run_command} \n \n'
                        f'Execute below command to deploy the curated GSC image'
                        f'{custom_image_dns_info}:\n'
-                       f'{workload_run.format(host_net, verifier_server, gsc_app_image)}')
+                       f'{workload_run.format(flags, verifier_server, gsc_app_image)}')
     else:
-        run_command = run_command_no_att.format(host_net, gsc_app_image)
+        run_command = run_command_no_att.format(flags, gsc_app_image)
 
     user_info = [image_ready_messg.format(gsc_app_image), commands_file + color_set,
                 app_exit_messg]

--- a/Curated-Apps/util/constants.py
+++ b/Curated-Apps/util/constants.py
@@ -49,11 +49,12 @@ index = ['The target deployment environment is assumed to be an Azure Confidenti
          '1. Distro selection',
          '2. Command-line arguments',
          '3. Environment variables',
-         '4. Encrypted files and key provisioning',
-         '5. Remote Attestation',
-         '6. Enclave signing',
-         '7. Generation of the final curated images',
-         '8. Generation of docker run commands']
+         '4. Additional docker run flags',
+         '5. Encrypted files and key provisioning',
+         '6. Remote Attestation',
+         '7. Enclave signing',
+         '8. Generation of the final curated images',
+         '9. Generation of docker run commands']
 
 distro_prompt = ['>> Distro Selection:', 'Provide the distro of your base image',
                  '- Press 1 for Ubuntu 18.04',
@@ -122,6 +123,17 @@ env_help =  ['This step secures the environment variables. Gramine will ignore e
              ' variables specified at runtime, so please ensure you provide those here.'
              ' By default Gramine will add all the environment variables set in the base'
              ' docker image.']
+
+flags_input = ['>> Additional docker run flags:','Specify docker run flags here in a single string.'
+             ' For example, if your docker command is ', 'docker run flag1 flag2 <image_name>'
+             + color_set, 'then the flags that need to be provided here are', 'flag1 flag2'
+             + color_set, 'Press CTRL+G when done']
+flags_help =  ['At the end of this Curation app, it writes instructions into commands.txt to run'
+               ' the curated images. If you have Docker container flags/configurations which should'
+               ' be added to the `docker run` instructions, please specify them here or modify'
+               ' the final commands in commands.txt at the end of curation.', 'Examples of'
+               ' docker flags: --rm, --name, --network, etc.' + color_set]
+
 wait_message = ['Image Creation:', 'Your Gramine Shielded Container image is being created.'
                 ' This might take a few minutes.']
 system_config_message = ['System config by default is assumed to be an Azure Confidential compute'


### PR DESCRIPTION
As of now curation app doesn't have provision to input additional docker flags (--name, --rm, -p, etc.). Hence these flags cannot be added to the `docker run` commands generated by curation app in commands.txt. This PR provides option to input these flags which ultimately gets added to `docker run` instructions for running the curated images, please refer the attached screenshot for the UI related changes.
![docker flags 2](https://user-images.githubusercontent.com/15154645/204280378-7f7b52a0-eb19-4072-9a63-ef40f17957fc.jpg)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/contrib/13)
<!-- Reviewable:end -->
