### PR TITLE
[Curation] Use GSC 1.3.1 instead of latest master

### DIFF
--- a/Curated-Apps/util/curation_script.sh
+++ b/Curated-Apps/util/curation_script.sh
@@ -85,7 +85,7 @@ create_gsc_image () {
     echo
     cd $CUR_DIR
     rm -rf gsc >/dev/null 2>&1
-    git clone --depth 1 https://github.com/gramineproject/gsc.git
+    git clone --depth 1 --branch v1.3.1 https://github.com/gramineproject/gsc.git
     cp $signing_key_path gsc/enclave-key.pem
 
     cd gsc


### PR DESCRIPTION
Curation currently uses GSC latest master and with tomli changes, it breaks curation. This PR forces curation to use GSC 1.3.1.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/contrib/15)
<!-- Reviewable:end -->
