### PR TITLE
[Curated Apps] Support insecure command-line args for test gsc images

### DIFF
--- a/Curated-Apps/workloads/pytorch/pytorch.manifest.template
+++ b/Curated-Apps/workloads/pytorch/pytorch.manifest.template
@@ -6,8 +6,7 @@ sgx.enclave_size = "4G"
 sgx.thread_num = 128
 loader.pal_internal_mem_size = "128M"
 
-# This is required to run workload as non-root user, any random number works except `0` which
-# is for root.
+# This is required to run workload as non-root user, any number works except `0` which is for root.
 loader.uid=999
 loader.gid=999
 

--- a/Curated-Apps/workloads/redis/redis.manifest.template
+++ b/Curated-Apps/workloads/redis/redis.manifest.template
@@ -5,8 +5,7 @@ sgx.nonpie_binary = true
 sgx.enclave_size = "1024M"
 sgx.thread_num = 8
 
-# This is required to run workload as non-root user, any random number works except `0` which
-# is for root.
+# This is required to run workload as non-root user, any number works except `0` which is for root.
 loader.uid=999
 loader.gid=999
 


### PR DESCRIPTION
Current implementation missing support for command line arguments while generating non-production GSC image. This PR add support for command-line arguments.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/contrib/18)
<!-- Reviewable:end -->
