### PR TITLE
Add AKV Dockerfile templates for signing with gsc

### DIFF
--- a/Integrations/azure/akv-sign/Dockerfile.sign.akv.centos.template
+++ b/Integrations/azure/akv-sign/Dockerfile.sign.akv.centos.template
@@ -1,0 +1,34 @@
+FROM {{image}} as unsigned_image
+
+# Install the required packages using root user
+USER root
+
+{% block install %}
+RUN dnf update -y \
+        && dnf install -y \
+        curl \
+        wget \
+        && /usr/bin/python3 -B -m pip install azure-keyvault-keys azure-identity
+
+RUN rpm --import https://packages.microsoft.com/keys/microsoft.asc
+RUN dnf install -y https://packages.microsoft.com/config/rhel/8/packages-microsoft-prod.rpm
+RUN dnf install -y azure-cli
+{% endblock %}
+
+RUN wget -P /gramine/app_files/ https://raw.githubusercontent.com/gramineproject/contrib/master/Integrations/azure/akv-sign/gramine-sgx-akv-sign
+
+RUN chmod +x /gramine/app_files/gramine-sgx-akv-sign
+
+RUN az login
+
+RUN {% block path %}{% endblock %} /gramine/app_files/gramine-sgx-akv-sign \
+      --url <akv_mhsm_url> \
+      --key <akv_sign_key> \
+      --manifest /gramine/app_files/entrypoint.manifest \
+      --output /gramine/app_files/entrypoint.manifest.sgx
+
+# This trick removes all temporary files from the previous commands
+FROM {{image}}
+
+COPY --from=unsigned_image /gramine/app_files/*.sig /gramine/app_files/
+

--- a/Integrations/azure/akv-sign/Dockerfile.sign.akv.debian.template
+++ b/Integrations/azure/akv-sign/Dockerfile.sign.akv.debian.template
@@ -1,0 +1,34 @@
+FROM {{image}} as unsigned_image
+
+# Install the required packages using root user
+USER root
+
+{% block install %}
+RUN dnf update -y \
+        && dnf install -y \
+        curl \
+        wget \
+        && /usr/bin/python3 -B -m pip install azure-keyvault-keys azure-identity
+
+RUN rpm --import https://packages.microsoft.com/keys/microsoft.asc
+RUN dnf install -y https://packages.microsoft.com/config/rhel/8/packages-microsoft-prod.rpm
+RUN dnf install -y azure-cli
+{% endblock %}
+
+RUN wget -P /gramine/app_files/ https://raw.githubusercontent.com/gramineproject/contrib/master/Integrations/azure/akv-sign/gramine-sgx-akv-sign
+
+RUN chmod +x /gramine/app_files/gramine-sgx-akv-sign
+
+RUN az login
+
+RUN {% block path %}{% endblock %} /gramine/app_files/gramine-sgx-akv-sign \
+      --url <akv_mhsm_url> \
+      --key <akv_sign_key> \
+      --manifest /gramine/app_files/entrypoint.manifest \
+      --output /gramine/app_files/entrypoint.manifest.sgx
+
+# This trick removes all temporary files from the previous commands
+FROM {{image}}
+
+COPY --from=unsigned_image /gramine/app_files/*.sig /gramine/app_files/
+

--- a/Integrations/azure/akv-sign/README.md
+++ b/Integrations/azure/akv-sign/README.md
@@ -4,9 +4,9 @@ SGX enclaves must be signed using a 3072-bit RSA key. This key needs to be
 protected and must not be disclosed to anyone. Typically for production
 deployments, you should use a key secured in a Hardware Security Module (HSM).
 
-This directory contains a plugin to Gramine tools that enables support for
-production signing of SGX enclaves using keys from Azure Key Vault (AKV) Managed
-HSM.
+This directory contains the plugin to Gramine tools and templates that enable
+support for production signing of SGX enclaves using keys from Azure Key Vault
+(AKV) Managed HSM.
 
 ## Prerequisites for SGX enclave signing
 
@@ -32,3 +32,13 @@ The command to sign the enclave with AKV's Managed HSM looks like this:
 
 where `sgx_sign_key` is the name of the RSA private key created in the AKV's
 Managed HSM with Vault URL `https://myakv-mhsm.managedhsm.azure.net`.
+
+## Templates for use with Gramine Shielded Containers (GSC)
+
+GSC `sign-image` command can take in a user supplied Dockerfile
+as an argument to `--template` and sign the graminized docker image. These
+templates can be used when a HSM is needed for signing. This directory has
+templates for using AKV to sign the graminized docker image. Please
+note that these are templates and the users will need to update the template
+with the required details to make it a 'self-contained' Dockerfile before
+passing it to `sign-image` command.


### PR DESCRIPTION
Signed-off-by: Sankaranarayanan Venkatasubramanian <sankaranarayanan.venkatasubramanian@intel.com>

These templates can be used after this PR [Enable `--template` option to use with `sign-image` (for use with HSMs, for example) by svenkata9 · Pull Request #112 · gramineproject/gsc (github.com)](https://github.com/gramineproject/gsc/pull/112) in GSC repo gets merged.