### PR TITLE
[Curated-Apps] Workaround for empty instruction `CMD [""]` added by GSC

### DIFF
--- a/Curated-Apps/util/curation_script.sh
+++ b/Curated-Apps/util/curation_script.sh
@@ -170,7 +170,14 @@ touch $entrypoint_script
 # Copying the complete binary string to the entrypoint script file
 echo '#!/bin/bash' >> $entrypoint_script
 echo '' >> $entrypoint_script
-echo $complete_binary_cmd' "${@}"' >> $entrypoint_script
+
+# TODO: This is a workaround, actual fix will go in GSC with PR #113
+# This workaround should be removed when contrib starts using GSC v1.4 with PR #113 merged
+echo 'if [[ "$#" -le "1" && "$1" -eq "" ]]; then
+    '$complete_binary_cmd'
+else
+    '$complete_binary_cmd' "${@}"
+fi' >> $entrypoint_script
 
 # Test image creation
 if [ "$6" = "test-image" ]; then


### PR DESCRIPTION
Redis run fails with below error:

```Error Produced:
*** FATAL CONFIG FILE ERROR (Redis 7.0.5) ***
Reading the configuration file, at line 3
>>> 'save "" ""'
Invalid save parameters
```
GSC retrieves arguments by reading the CMD instruction in docker base image. If CMD is empty, GSC add cmd instruction with double quotes like this `CMD[""]` which is passed by `apploader.sh` to `entry_script_redis.sh`
In case of Redis, generated `entry_script_redis.sh` have:

`docker-entrypoint.sh --protected-mode no --save ' ${@}`

during execution `${@} is translated to `""` and final `entry_script_redis.sh` look like:
`docker-entrypoint.sh --protected-mode no --save '' ""`

So extra `""` added by GSC when `CMD` instruction in base docker image is empty, causes the issue with redis. `CMD [""]` Generation in `Docker.build` by GSC should be prevented if cmd in base docker image is empty.

PR #113 is raised to fix it in GSC repo but as we cannot use unreleased version of GSC in curation, we need to have a workaround in contrib repo. This PR provide a temporary workaround for the issue.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/contrib/21)
<!-- Reviewable:end -->
