### PR TITLE
[Curated-Apps] Adapt to latest GSC

### DIFF
--- a/Curated-Apps/README.md
+++ b/Curated-Apps/README.md
@@ -19,7 +19,8 @@ learning.
 - Install the necessary build dependencies as shown below (for Ubuntu).
 ```sh
  $ sudo apt-get update && sudo apt-get install jq docker.io python3 python3-pip
- $ pip3 install docker jinja2 toml pyyaml
+ $ pip3 install docker jinja2 tomli tomli-w pyyaml
+ $ pip3 install toml  # for compatibility with Gramine v1.3 or lower
  $ sudo chown $USER /var/run/docker.sock
 ```
 

--- a/Curated-Apps/curate.py
+++ b/Curated-Apps/curate.py
@@ -478,7 +478,7 @@ def main(stdscr, argv):
         if len(isv_svn_list) > 0: isv_svn = isv_svn_list[0]
 
         verifier_run_command = (f'Execute below command to start verifier on a trusted system:\n'
-                                f'$ docker run {host_net} --device=/dev/sgx/enclave '
+                                f'$ docker run {host_net} --device=/dev/sgx/enclave:/dev/sgx_enclave '
                                 f'-e RA_TLS_MRENCLAVE={mr_enclave} -e RA_TLS_MRSIGNER={mr_signer} '
                                 f'-e RA_TLS_ISV_PROD_ID={isv_prod_id} -e RA_TLS_ISV_SVN={isv_svn} '
                                 f'{debug_enclave_env_ver_ext}' + verifier_cert_mount_str + ' ' +

--- a/Curated-Apps/util/config.yaml.template
+++ b/Curated-Apps/util/config.yaml.template
@@ -24,5 +24,5 @@ Gramine:
 #         Branch:     ""
 #
 SGXDriver:
-    Repository: "https://github.com/intel/SGXDataCenterAttestationPrimitives.git"
-    Branch:     "DCAP_1.11 && cp -r driver/linux/* ."
+    Repository: ""
+    Branch:     ""

--- a/Curated-Apps/util/constants.py
+++ b/Curated-Apps/util/constants.py
@@ -30,7 +30,7 @@ test_run_instr = ('Run the {} docker image in an Azure Confidential Compute'
                   'Host networking (--net=host) is optional\n\n{}\n\n'
                   'Above command is saved to command.txt as well.'
                   ' Press any key to exit the app')
-test_run_cmd = ('$ docker run --net=host --device=/dev/sgx/enclave -it {}')
+test_run_cmd = ('$ docker run --net=host --device=/dev/sgx/enclave:/dev/sgx_enclave -it {}')
 image_not_found_warn = ('Warning: Cannot find application Docker image `{}`.\n'
                         'Fetching from Docker Hub ...\n\n')
 log_progress = 'You may monitor {} for detailed progress\n\n'
@@ -138,7 +138,7 @@ wait_message = ['Image Creation:', 'Your Gramine Shielded Container image is bei
                 ' This might take a few minutes.']
 system_config_message = ['System config by default is assumed to be an Azure Confidential compute'
                          ' instance.']
-run_command_no_att = '$ docker run {} --device=/dev/sgx/enclave -it {}'
+run_command_no_att = '$ docker run {} --device=/dev/sgx/enclave:/dev/sgx_enclave -it {}'
 run_with_debug = 'python3 curate.py {} {} debug' + color_set
 extra_debug_instr = ("It's also possible that you may run into issues resulting from lack of"
                      ' sufficient enclave memory pages, or insufficient number of threads.'
@@ -152,7 +152,7 @@ image_ready_messg  = ('The curated GSC image {} is ready, please follow the inst
 image_ready_messg_att = ('The curated GSC image , and the remote attestation verifier'
                          ' image is ready, You can run the images using the instructions provided'
                          ' in the below file.')
-workload_run = ('$ docker run {} --device=/dev/sgx/enclave -e SECRET_PROVISION_SERVERS={}'
+workload_run = ('$ docker run {} --device=/dev/sgx/enclave:/dev/sgx_enclave -e SECRET_PROVISION_SERVERS={}'
                 ' -v /var/run/aesmd/aesm.socket:/var/run/aesmd/aesm.socket -it {}')
 enc_keys_mount = '-v {}:/keys'
 enc_key_path = '/keys/{}'


### PR DESCRIPTION
This PR have multiple fixes to adapt to latest gramine as described below:

1. Updated prerequisites for tomli in README
2. Droping support for out-of-tree DCAP SGX drivers with commit `0b60fa2` breaks contrib. Had to adapt `/util/config.yaml.template`. In case of non-in-kernel SGX driver, `/dev/sgx_enclave` doesn't exists. changes are made to mount it as `/dev/sgx/enclave`  as it's avaible in both non-in-kernel SGX and in-kernel SGX driver on Azure Confidential Compute VMs.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/contrib/25)
<!-- Reviewable:end -->
