### PR TITLE
[Curated-Apps] Skip curses usage for test mode

### DIFF
--- a/Curated-Apps/util/constants.py
+++ b/Curated-Apps/util/constants.py
@@ -22,18 +22,19 @@ partition_y = 7
 
 color_set = '::reverse'
 
-test_image_mssg = ('Your test GSC image is being generated. This image is not supposed to be'
-                   ' used in production \n\n')
+test_image_msg = ('\nYour test GSC image is being generated. This image is not supposed to be'
+                   ' used in production\n')
 
 test_run_instr = ('Run the {} docker image in an Azure Confidential Compute'
                   ' instance using the below command.\n\n'
                   'Host networking (--net=host) is optional\n\n{}\n\n'
-                  'Above command is saved to command.txt as well.'
-                  ' Press any key to exit the app')
+                  'Above command is saved to command.txt as well.\n')
 test_run_cmd = ('$ docker run --net=host --device=/dev/sgx/enclave -it {}')
 image_not_found_warn = ('Warning: Cannot find application Docker image `{}`.\n'
                         'Fetching from Docker Hub ...\n\n')
-log_progress = 'You may monitor {} for detailed progress\n\n'
+image_creation_failed = ('\n\n\n`{}` creation failed, exiting....\n\n'
+                         'For more info, look at the log file here: {}\n\n')
+log_progress = 'You may monitor {} for detailed progress\n'
 title = "Curate a Gramine Shielded Container (GSC) image"
 
 user_win_title = 'User Agent'


### PR DESCRIPTION
Fixes #26: Copying `docker run command` in test page that spills over to new line does not work.

Details: With current implementation, curses is used from start of the main function. curation app, at the end of image curation in test mode, prints the `docker run command` on screen which could spill over to next line. In this case when user copy the command from screen which spilled over to next line contains newline character `\n` which is wrong and doesn't work when executed.

Root cause: curses defines screen size and if something doesn't fit it add newline `\n` character and spill over the remaining contents to next line.

Fix in PR: Instead of using curses at the start of main, use curses only in `custom image creation` where we need UI.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/contrib/29)
<!-- Reviewable:end -->
