### PR TITLE
[Curated-Apps] Add encryption key in the manifest for testing without attestation

### DIFF
--- a/Curated-Apps/curate.py
+++ b/Curated-Apps/curate.py
@@ -395,26 +395,16 @@ def create_custom_image(stdscr, docker_socket, workload_type, base_image_name, d
     host_net = ''
     update_user_and_commentary_win_array(user_console, guide_win, attestation_prompt,
                                          attestation_help)
-    while True:
-        attestation_input = get_attestation_input(user_console, guide_win)
-        if attestation_input == 'done':
-            attestation_required = 'y'
-            ca_cert_path = ssl_folder_path_on_host+'/ca.crt'
 
-        elif attestation_input == 'test':
-            ca_cert_path, verifier_server = ssl_folder_path_on_host+'/ca.crt', '"localhost:4433"'
-            host_net, config = '--net=host', 'test'
-            attestation_required = 'y'
+    attestation_input = get_attestation_input(user_console, guide_win)
+    if attestation_input == 'done':
+        attestation_required = 'y'
+        ca_cert_path = ssl_folder_path_on_host+'/ca.crt'
 
-        if ef_required == 'y' and attestation_required == 'n':
-            user_console.erase()
-            update_user_and_commentary_win_array(user_console, guide_win, attestation_prompt,
-                                                 attestation_help)
-            error = ('You require Remote Attestation to provision the key for encrypted files.')
-            update_user_error_win(user_console, error)
-            continue
-
-        break
+    elif attestation_input == 'test':
+        ca_cert_path, verifier_server = ssl_folder_path_on_host+'/ca.crt', '"localhost:4433"'
+        host_net, config = '--net=host', 'test'
+        attestation_required = 'y'
 
     # 7. Obtain enclave signing key
     update_user_and_commentary_win_array(user_console, guide_win, key_prompt, signing_key_help)
@@ -447,8 +437,8 @@ def create_custom_image(stdscr, docker_socket, workload_type, base_image_name, d
                                          [log_progress.format(log_file)])
     subprocess.call(['util/curation_script.sh', workload_type, base_image_name, distro,
                      key_path, args, attestation_required, debug_flag, ca_cert_path, env_required,
-                     envs, ef_required, encrypted_files, passphrase], stdout=log_file_pointer,
-                     stderr=log_file_pointer)
+                     envs, ef_required, encrypted_files, os.path.abspath(encryption_key),
+                     passphrase], stdout=log_file_pointer, stderr=log_file_pointer)
     image = gsc_app_image
     check_image_creation_success(user_console, docker_socket, image, log_file)
 

--- a/Curated-Apps/util/constants.py
+++ b/Curated-Apps/util/constants.py
@@ -82,7 +82,9 @@ attestation_prompt = ['>> Remote Attestation:' , 'To enable remote attestation u
                       ' a decryption key for encrypted files.',
                       '- Type done when ready, OR',
                       '- Type test to create test certificates, OR',
-                      '- No input (blank) to skip attestation',
+                      '- No input (blank) to skip attestation. Encryption key will be hard-coded in'
+                      ' the manifest if user had input encryption files in the previous step. This'
+                      ' option is thus insecure and must not be used in production environments!',
                       'Press CTRL+G when done']
 attestation_help = ['This step enables the enclave to communicate to a remote verifier over'
                     ' an Remote Attestation TLS (RA-TLS) link. This remote verifier uses Azure'

--- a/Curated-Apps/workloads/pytorch/base_image_helper/encrypted_files.txt
+++ b/Curated-Apps/workloads/pytorch/base_image_helper/encrypted_files.txt
@@ -1,0 +1,1 @@
+classes.txt:input.jpg:alexnet-pretrained.pt:result.txt


### PR DESCRIPTION
Summary of the changes in PR:
1. Hard-code encryption key in the manifest when user opts to test without attestation. This is useful in cases where user wants to test encrypted files functionality without attestation.
2. Developers had to modify `curation_script.sh` everytime while curating new apps having encrypted files list in the base image in test mode. Now developers just have to create `encrypted_files` and add encrypted files to the file.
3. Old implementation use to prefix `PWD` to all the encypted files while creating mount point in manifest even if path is absolute. Now prefixing `PWD` is skipped if path is absolute.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/contrib/30)
<!-- Reviewable:end -->
