### PR TITLE
[Curated-Apps] Add attestation env variables used with debug enclave

### DIFF
--- a/Curated-Apps/curate.py
+++ b/Curated-Apps/curate.py
@@ -448,7 +448,7 @@ def create_custom_image(stdscr, docker_socket, workload_type, base_image_name, d
     commands_fp = open(commands_file, 'w')
     if attestation_required == 'y':
         debug_enclave_env_ver_ext = ''
-        if config == 'test':
+        if config == 'test' or debug_flag == 'y':
             debug_enclave_env_ver_ext = debug_enclave_env_verifier
 
         ssl_folder_abs_path_on_host = os.path.abspath(ssl_folder_path_on_host)


### PR DESCRIPTION
To test debug build with remote attestation, verifier `docker run` command must have  `-e 
 A_TLS_ALLOW_DEBUG_ENCLAVE_INSECURE=1 -e  RA_TLS_ALLOW_OUTDATED_TCB_INSECURE=1` environment variables.

These environment variables were missing for debug builds. This PR add them.

Fixes #32

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/contrib/33)
<!-- Reviewable:end -->
