### PR TITLE
[Curated-Apps] Update Tensorflow base image to Ubuntu 20.04; Copyright to 2023

### DIFF
--- a/Curated-Apps/workloads/tensorflow-serving/base_image_helper/Dockerfile
+++ b/Curated-Apps/workloads/tensorflow-serving/base_image_helper/Dockerfile
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
 # Copyright (C) 2022 Intel Corporation
 
-FROM gramine.azurecr.io:443/base_images/intel-optimized-tensorflow-serving-avx512-ubuntu18.04
+FROM gramine.azurecr.io:443/base_images/intel-optimized-tensorflow-serving-avx512-ubuntu20.04
 
 COPY models/resnet ./models/resnet
 COPY models/mnist ./models/mnist

--- a/Curated-Apps/workloads/tensorflow-serving/base_image_helper/Dockerfile
+++ b/Curated-Apps/workloads/tensorflow-serving/base_image_helper/Dockerfile
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
-# Copyright (C) 2022 Intel Corporation
+# Copyright (C) 2023 Intel Corporation
 
 FROM gramine.azurecr.io:443/base_images/intel-optimized-tensorflow-serving-avx512-ubuntu20.04
 

--- a/Curated-Apps/workloads/tensorflow-serving/tensorflow-serving.manifest.template
+++ b/Curated-Apps/workloads/tensorflow-serving/tensorflow-serving.manifest.template
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
-# Copyright (C) 2022 Intel Corporation
+# Copyright (C) 2023 Intel Corporation
 
 # This file has basic set of values defined for graminizing tensorflow-serving images. This manifest template
 # is used by `curation_script.sh` to create the user manifest file that will be passed to GSC.


### PR DESCRIPTION
This PR updates the TFS base image to use Ubuntu 20.04 (since Ubuntu 18.04 will be seeing EOL soon). It also updates the copyright header to 2023.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/contrib/37)
<!-- Reviewable:end -->
