### PR TITLE
[Curated-Apps] Update Gramine docs link

### DIFF
--- a/Intel-Confidential-Compute-for-X/workloads/mysql/README.md
+++ b/Intel-Confidential-Compute-for-X/workloads/mysql/README.md
@@ -34,7 +34,7 @@ Perform the following steps on your system:
 
 4. Encrypt MySQL database:
 
-    1. [Install Gramine](https://gramine.readthedocs.io/en/latest/quickstart.html#install-gramine)
+    1. [Install Gramine](https://gramine.readthedocs.io/en/stable/quickstart.html#install-gramine)
         as the encryption is done using the `gramine-sgx-pf-crypt` tool which is part of Gramine
         installation.
 

--- a/Intel-Confidential-Compute-for-X/workloads/pytorch/base_image_helper/README.md
+++ b/Intel-Confidential-Compute-for-X/workloads/pytorch/base_image_helper/README.md
@@ -9,7 +9,7 @@ model and an encrypted sample picture.
         python3 -m pip install --upgrade pip # on ubuntu 18.04 machine
         python3 -m pip install --user torchvision pillow
         ```
-- [Install Gramine](https://gramine.readthedocs.io/en/latest/quickstart.html#install-gramine)
+- [Install Gramine](https://gramine.readthedocs.io/en/stable/quickstart.html#install-gramine)
     as the encryption is done using the `gramine-sgx-pf-crypt` tool which is part of Gramine
     installation.
     You can learn more about Gramine's support of encrypted files in the


### PR DESCRIPTION
Some workloads uses latest version of gramine documentation which is broken now instead curated app should use the stable version.

This PR uses the stable version of gramine documentation.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/contrib/48)
<!-- Reviewable:end -->
