### PR TITLE
[Curated-Apps] Eliminate the need for jq package

### DIFF
--- a/Intel-Confidential-Compute-for-X/README.md
+++ b/Intel-Confidential-Compute-for-X/README.md
@@ -35,7 +35,7 @@ application, and adjusting the settings and templates as needed.
   the current user:
    - Ubuntu 18.04
         ```sh
-        sudo apt-get update && sudo apt-get install jq docker.io python3 python3-pip
+        sudo apt-get update && sudo apt-get install -y docker.io python3 python3-pip
         python3 -m pip install docker jinja2 tomli tomli-w pyyaml
         sudo chown $USER /var/run/docker.sock
         ```

--- a/Intel-Confidential-Compute-for-X/util/curation_script.sh
+++ b/Intel-Confidential-Compute-for-X/util/curation_script.sh
@@ -78,7 +78,7 @@ add_encrypted_files_to_manifest() {
     IFS=':' # Setting colon as delimiter
     read -a ef_files_list <<<"$1"
     unset IFS
-    workdir_base_image="$(docker image inspect "$base_image" | jq '.[].Config.WorkingDir')"
+    workdir_base_image="$(docker image inspect -f '{{.Config.WorkingDir}}' $base_image)"
     workdir_base_image=`sed -e 's/^"//' -e 's/"$//' <<<"$workdir_base_image"`
     encrypted_files_string=''
     for i in "${ef_files_list[@]}"


### PR DESCRIPTION
`jq`  was needed at one place which can be replaced with other logic, hence can be removed from pre requisites. We have seen multiple instances people missing out installing `jq` package which breaks the curated apps at run time and become hard to root cause. This PR will prevent such cases.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/contrib/49)
<!-- Reviewable:end -->
