### PR TITLE
[Curated-Apps] Change scikit-learn base image

### DIFF
--- a/Intel-Confidential-Compute-for-X/workloads/sklearn/base_image_helper/Dockerfile
+++ b/Intel-Confidential-Compute-for-X/workloads/sklearn/base_image_helper/Dockerfile
@@ -1,11 +1,11 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
 # Copyright (C) 2022 Intel Corporation
 
-FROM bitnami/scikit-learn-intel
+FROM intel/intel-optimized-ml:scikit-learn-2023.1.1-xgboost-1.7.5-pip-base
 
 RUN pip3 install pandas
 
-COPY kmeans_perf_eval.py /app/
-COPY data /app/data
+COPY kmeans_perf_eval.py ./
+COPY data ./data
 
 CMD ["python3", "kmeans_perf_eval.py"]

--- a/Intel-Confidential-Compute-for-X/workloads/sklearn/base_image_helper/kmeans_perf_eval.py
+++ b/Intel-Confidential-Compute-for-X/workloads/sklearn/base_image_helper/kmeans_perf_eval.py
@@ -24,6 +24,7 @@ def run(X, y, is_patched):
 
     params = {
         'n_clusters': 10,
+        'n_init': 10,
         'random_state': 123,
         'copy_x': False,
     }


### PR DESCRIPTION
Currently used `bitnami/scikit-learn-intel` base image for scikit-learn curation is removed from dockerhub, hence scikit-learn curation is broken.

This PR uses `intel/intel-optimized-ml:scikit-learn-2023.1.1-xgboost-1.7.5-pip-base` as base image for scikit-learn curation.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/contrib/50)
<!-- Reviewable:end -->
