### PR TITLE
[Curated-Apps] Concat LD_PRELOAD if exists in workload manifest file

### DIFF
--- a/Intel-Confidential-Compute-for-X/util/curation_script.sh
+++ b/Intel-Confidential-Compute-for-X/util/curation_script.sh
@@ -187,9 +187,17 @@ if [ "$attestation_required" = "y" ]; then
     echo '' >> $app_image_manifest
     echo '# Attestation related entries' >> $app_image_manifest
     echo 'sgx.remote_attestation = "dcap"' >> $app_image_manifest
-    echo 'loader.env.LD_PRELOAD = ' \
-    '"/gramine/meson_build_output/lib/x86_64-linux-gnu/libsecret_prov_attest.so"' >> \
-    $app_image_manifest
+
+    # Preload `libsecret_prov_attest.so` library. But if `LD_PRELOAD` exists in workload
+    # specific manifest, then we must concatenate our lib with already-listed libs.
+    secret_prov_attest="/gramine/meson_build_output/lib/x86_64-linux-gnu/libsecret_prov_attest.so"
+    if ! grep -q 'loader.env.LD_PRELOAD' $app_image_manifest; then
+        echo 'loader.env.LD_PRELOAD = "'$secret_prov_attest'"' >> $app_image_manifest
+    else
+        sed -i "s|\(^loader.env.LD_PRELOAD[[:space:]]*=[[:space:]]*.*\)\"|\1:$secret_prov_attest\"|g" \
+            $app_image_manifest
+    fi
+
     echo 'loader.env.SECRET_PROVISION_SERVERS = { passthrough = true }' >> $app_image_manifest
     echo 'loader.env.SECRET_PROVISION_CONSTRUCTOR = "1"' >> $app_image_manifest
     echo 'loader.env.SECRET_PROVISION_CA_CHAIN_PATH = "/ca.crt"' >> $app_image_manifest


### PR DESCRIPTION
We preload `libsecret_prov_attest.so` library if remote attestation is selected by user. But if `LD_PRELOAD` exists in workload specific manifest, then we will have two LD_PRELOAD which will result in `Duplicate Key` error.

This PR fixes this by concatenating the LD_PRELOAD with workload specific manifest.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/contrib/53)
<!-- Reviewable:end -->
