### PR TITLE
[Curated-Apps] Use latest image tags

### DIFF
--- a/Intel-Confidential-Compute-for-X/workloads/mariadb/README.md
+++ b/Intel-Confidential-Compute-for-X/workloads/mariadb/README.md
@@ -26,7 +26,7 @@ Perform the following steps on your system:
    mkdir workloads/mariadb/test_db
    docker run --rm --net=host --name init_test_db \
        -v $PWD/workloads/mariadb/test_db:/test_db \
-       -e MARIADB_RANDOM_ROOT_PASSWORD=yes -e MARIADB_DATABASE=test_db mariadb:10.7 \
+       -e MARIADB_RANDOM_ROOT_PASSWORD=yes -e MARIADB_DATABASE=test_db mariadb:11.0.3-jammy \
        --datadir /test_db &
    docker stop init_test_db
    sudo chown -R $USER:$USER $PWD/workloads/mariadb/test_db
@@ -60,7 +60,7 @@ Perform the following steps on your system:
     - To generate a Gramine-protected, pre-configured, non-production ready, test image for MariaDB,
       execute the following script:
       ```sh
-      python3 ./curate.py mariadb mariadb:10.7 test
+      python3 ./curate.py mariadb mariadb:11.0.3-jammy test
       ```
     - To generate a Gramine-protected, pre-configured MariaDB image based on a user-provided MariaDB
       image, execute the following to launch an interactive setup script:

--- a/Intel-Confidential-Compute-for-X/workloads/mysql/README.md
+++ b/Intel-Confidential-Compute-for-X/workloads/mysql/README.md
@@ -27,7 +27,7 @@ Perform the following steps on your system:
    mkdir workloads/mysql/test_db
    docker run --rm --net=host --name init_test_db --user $(id -u):$(id -g) \
        -v $PWD/workloads/mysql/test_db:/test_db \
-       -e MYSQL_ALLOW_EMPTY_PASSWORD=true -e MYSQL_DATABASE=test_db mysql:8.0.32-debian \
+       -e MYSQL_ALLOW_EMPTY_PASSWORD=true -e MYSQL_DATABASE=test_db mysql:8.0.34-debian \
        --datadir /test_db &
    docker stop init_test_db
    ```
@@ -54,7 +54,7 @@ Perform the following steps on your system:
     - To generate a Gramine-protected, pre-configured, non-production ready, test image for MySQL,
       execute the following script:
       ```sh
-      python3 ./curate.py mysql mysql:8.0.32-debian test
+      python3 ./curate.py mysql mysql:8.0.34-debian test
       ```
     - To generate a Gramine-protected, pre-configured MySQL image based on a user-provided MySQL
       image, execute the following to launch an interactive setup script:

--- a/Intel-Confidential-Compute-for-X/workloads/pytorch/base_image_helper/Dockerfile
+++ b/Intel-Confidential-Compute-for-X/workloads/pytorch/base_image_helper/Dockerfile
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
 # Copyright (C) 2022 Intel Corporation
 
-FROM pytorch/pytorch:latest
+FROM pytorch/pytorch:2.0.1-cuda11.7-cudnn8-runtime
 COPY input.jpg ./
 COPY classes.txt ./
 COPY alexnet-pretrained.pt ./

--- a/Intel-Confidential-Compute-for-X/workloads/redis/README.md
+++ b/Intel-Confidential-Compute-for-X/workloads/redis/README.md
@@ -23,7 +23,7 @@ Perform the following steps on your system:
    - To generate a Gramine-protected, pre-configured, non-production ready, test image for Redis,
      execute the following script:
      ```sh
-     python3 ./curate.py redis redis:7.0.0 test
+     python3 ./curate.py redis redis:7.0.10 test
      ```
    - To generate a Gramine-protected, pre-configured Redis image based on a user-provided Redis
      image, execute the following to launch an interactive setup script:


### PR DESCRIPTION
Redis, PyTorch, MySQL and MariaDB image tags are updated.

Redis 7.0.11 onwards is based on debian 12 which is not supported
in GSC yet, hence using 7.0.10 which is based on debian 11.

Memcached 1.6 onwards uses eventfd syscall which is insecure in
Gramine, hence keeping the current tag 1.5-20.04_beta.

TF-Serving is built locally and is latest based on Ubuntu:20.04.

OpenVINO Model Server and Sklearn already on latest tags.


<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/contrib/54)
<!-- Reviewable:end -->
