### PR TITLE
[Curated-Apps] Exit curation script on error

### DIFF
--- a/Intel-Confidential-Compute-for-X/util/curation_script.sh
+++ b/Intel-Confidential-Compute-for-X/util/curation_script.sh
@@ -35,6 +35,8 @@
 # -- arg13   : encryption key used for encrypting sensitive files such as models, data etc.
 # -- arg14   : Passphrase to the enclave signing key (if applicable)
 
+set -e
+
 echo printing args $0 $@
 
 workload_type=$1
@@ -46,8 +48,8 @@ WORKLOAD_DIR=$CUR_DIR'/workloads/'$workload_type
 cd $WORKLOAD_DIR
 rm -rf $CUR_DIR'/test' && mkdir $CUR_DIR'/test' >/dev/null 2>&1
 
-cp $wrapper_dockerfile'.template' $wrapper_dockerfile
-cp $app_image_manifest'.template' $app_image_manifest
+cp -f $wrapper_dockerfile'.template' $wrapper_dockerfile
+cp -f $app_image_manifest'.template' $app_image_manifest
 
 base_image="$2"
 distro="$3"
@@ -124,7 +126,7 @@ create_gsc_image () {
     rm -rf gsc >/dev/null 2>&1
     git clone --depth 1 --branch v1.5 https://github.com/gramineproject/gsc.git
     cd gsc
-    cp config.yaml.template config.yaml
+    cp -f config.yaml.template config.yaml
     sed -i 's|ubuntu:.*|'$distro'"|' config.yaml
 
     if [ "$1" = "y" ]; then
@@ -182,7 +184,7 @@ fi
 attestation_required=$6
 if [ "$attestation_required" = "y" ]; then
     ca_cert_path=$8
-    cp $CUR_DIR/$ca_cert_path ca.crt
+    cp -f $CUR_DIR/$ca_cert_path ca.crt
     copy_cert_files='COPY ca.crt /'
     echo '' >> $app_image_manifest
     echo '# Attestation related entries' >> $app_image_manifest

--- a/Intel-Confidential-Compute-for-X/verifier/helper.sh
+++ b/Intel-Confidential-Compute-for-X/verifier/helper.sh
@@ -25,7 +25,7 @@ rm -rf  ssl_common >/dev/null 2>&1
 mkdir -p ssl_common
 
 if [ "$1" = "done" ]; then
-    cp ssl/ca.crt ssl/server.crt ssl/server.key ssl_common/
+    cp -f ssl/ca.crt ssl/server.crt ssl/server.key ssl_common/
 else
     openssl genrsa -out ssl_common/ca.key 2048
     openssl req -x509 -new -nodes -key ssl_common/ca.key -sha256 -days 1024 -out ssl_common/ca.crt -config ca_config.conf
@@ -34,7 +34,7 @@ else
     openssl x509 -req -days 360 -in ssl_common/server.csr -CA ssl_common/ca.crt -CAkey ssl_common/ca.key -CAcreateserial -out ssl_common/server.crt
 fi
 
-cp verifier.dockerfile.template verifier.dockerfile
+cp -f verifier.dockerfile.template verifier.dockerfile
 
 args=''
 # Use `secret_prov_pf` if base image has encrypted files


### PR DESCRIPTION
This PR fixes two issues as explained below:
1. Curation script doesn't exit immediatly on any error, we have seen it multiple cases when `gsc build` fails but curation proceed to next spte of signing the image. Added `set -e` to fix this.
2. Curation script executed by non-root user doesn't override the files `<workload>.manifest`, `<workload>-gsc.dockerfile` etc files  already created by root user `-f` with `cp` fixes that. Code lines: [here](https://github.com/gramineproject/contrib/blob/be92cdebc212e38690366aa7d7d3c2e2b78d86be/Intel-Confidential-Compute-for-X/util/curation_script.sh#L49-L50).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/contrib/55)
<!-- Reviewable:end -->
