### PR TITLE
[Curated-Apps] Fix commands of installing build dependencies

### DIFF
--- a/Intel-Confidential-Compute-for-X/README.md
+++ b/Intel-Confidential-Compute-for-X/README.md
@@ -72,11 +72,12 @@ for other distro specific commands.
 sudo apt-get update && sudo apt-get install -y docker.io
 sudo chown $USER /var/run/docker.sock
 
-echo 'deb [arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu focal main' |
+echo 'deb [arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu focal main' | \
     sudo tee /etc/apt/sources.list.d/intel-sgx.list
-wget -qO - https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key |
+wget -qO - https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | \
     sudo apt-key add -
-sudo apt-get install -y -f libsgx-dcap-ql libsgx-dcap-default-qpl=1.16.100.2-focal1
+sudo apt-get update && \
+    sudo apt-get install -y -f libsgx-dcap-ql libsgx-dcap-default-qpl=1.16.100.2-focal1
 
 # Execute below command (only on Azure VM) to change PCCS_URL to Azure PCCS
 sudo sed -i "s|^\(  \"pccs_url\": \"https://\).*\(/sgx/certification.*\)|\1global.acccache.azure.net\2|g" \


### PR DESCRIPTION
Fixes two issues:

1. Copying all command and executing does't work due to missing line-continuation character.
2. Registery update using command `sudo apt update` was missing because of which packages `libsgx-dcap-ql libsgx-dcap-default-qpl=1.16.100.2-focal1` installation fail.

This PR fixes above two issues.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/contrib/69)
<!-- Reviewable:end -->
