### PR TITLE
[Integrations/azure] Re-enable proxy support in libcurl

### DIFF
--- a/Integrations/azure/ra_tls_maa/subprojects/packagefiles/curl-8.4.0/compile.sh
+++ b/Integrations/azure/ra_tls_maa/subprojects/packagefiles/curl-8.4.0/compile.sh
@@ -29,6 +29,7 @@ cp -ar "$CURRENT_SOURCE_DIR" "$PRIVATE_DIR"
     # The list of configure options is selected based on:
     # https://github.com/curl/curl/blob/curl-8_4_0/docs/INSTALL.md#reducing-size
     ./configure                                     \
+        --enable-proxy                              \
         --disable-alt-svc                           \
         --disable-ares                              \
         --disable-cookies                           \
@@ -53,7 +54,6 @@ cp -ar "$CURRENT_SOURCE_DIR" "$PRIVATE_DIR"
         --disable-ntlm-wb                           \
         --disable-pop3                              \
         --disable-progress-meter                    \
-        --disable-proxy                             \
         --disable-pthreads                          \
         --disable-rtsp                              \
         --disable-shared                            \


### PR DESCRIPTION
For minimization purposes, libcurl is built with most features disabled. One of the disabled features was proxy support. This made libcurl-based dependencies, such as RA-TLS libs, unusable in proxy-restricted environments (e.g. with a company-wide proxy). This commit re-enables proxy support, which increases the size of `libcurl.a` by ~7%.

This commit is the same as commit "[curl] Re-enable proxy support in libcurl" in the core Gramine repo. See https://github.com/gramineproject/gramine/pull/1720

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/contrib/74)
<!-- Reviewable:end -->
