### PR TITLE
[packaging] Change Section to contrib/misc

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -6,7 +6,7 @@ Build-Depends: debhelper-compat (= 13),
  meson (>= 0.56),
  pkg-config,
 Standards-Version: 4.1.3
-Section: misc
+Section: contrib/misc
 Homepage: https://gramine.readthedocs.io/projects/contrib/
 Vcs-Browser: https://github.com/gramineproject/contrib
 Vcs-Git: https://github.com/gramineproject/contrib.git


### PR DESCRIPTION
This is a quick fix for packaging, mainly for my convenience, so when processing incoming packages in `reprepro`, the package lands in the correct component automatically, without resorting to overrides.