### PR TITLE
[Curated-Apps] Move to Gramine v1.6.1

### DIFF
--- a/Intel-Confidential-Compute-for-X/util/curation_script.sh
+++ b/Intel-Confidential-Compute-for-X/util/curation_script.sh
@@ -124,7 +124,7 @@ create_gsc_image () {
     echo
     cd $CUR_DIR
     rm -rf gsc >/dev/null 2>&1
-    git clone --depth 1 --branch v1.6 https://github.com/gramineproject/gsc.git
+    git clone --depth 1 --branch v1.6.1 https://github.com/gramineproject/gsc.git
     cd gsc
     cp -f config.yaml.template config.yaml
     sed -i 's|ubuntu:.*|'$distro'"|' config.yaml

--- a/Intel-Confidential-Compute-for-X/verifier/verifier.dockerfile.template
+++ b/Intel-Confidential-Compute-for-X/verifier/verifier.dockerfile.template
@@ -20,12 +20,12 @@ RUN echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/gramine-keyring.gpg] htt
 RUN env DEBIAN_FRONTEND=noninteractive apt-get update \
     && env DEBIAN_FRONTEND=noninteractive apt-get install -y \
     libsgx-dcap-default-qpl=1.16.100.2-jammy1 \
-    gramine=1.6
+    gramine
 
 RUN sed -i "s|^\(  \"pccs_url\": \"https://\).*\(/sgx/certification.*\)|\1api.trustedservices.intel.com\2|g" \
     /etc/sgx_default_qcnl.conf
 
-RUN git clone --depth 1 --branch v1.6 https://github.com/gramineproject/gramine.git
+RUN git clone --depth 1 --branch v1.6.1 https://github.com/gramineproject/gramine.git
 
 ARG server_dcap_type="secret_prov_minimal"
 RUN if [ $server_dcap_type="secret_prov_pf" ]; then \


### PR DESCRIPTION
With the new release of Gramine, old packages are replaced with new packages. Which causes verifier's build failure.

We always need a PR to fix it after every Gramine release.

With this PR, verifier will use latest Gramine packages and GSC version might not match with Gramine.

But for long term, we need to figure out a stable solution where we don't need such a PR after every Gramine release keeping Gramine and GSC versions same.

Please refer [PR#81](https://github.com/gramineproject/contrib/pull/81) for more details.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/contrib/82)
<!-- Reviewable:end -->
