### PR TITLE
[Curated-Apps] Auto fetch latest release tag

### DIFF
--- a/Intel-Confidential-Compute-for-X/util/curation_script.sh
+++ b/Intel-Confidential-Compute-for-X/util/curation_script.sh
@@ -124,8 +124,9 @@ create_gsc_image () {
     echo
     cd $CUR_DIR
     rm -rf gsc >/dev/null 2>&1
-    git clone --depth 1 --branch v1.6.1 https://github.com/gramineproject/gsc.git
+    git clone https://github.com/gramineproject/gsc.git
     cd gsc
+    git checkout $(git tag --list 'v*.*' --sort=taggerdate | tail -1)
     cp -f config.yaml.template config.yaml
     sed -i 's|ubuntu:.*|'$distro'"|' config.yaml
 

--- a/Intel-Confidential-Compute-for-X/verifier/verifier.dockerfile.template
+++ b/Intel-Confidential-Compute-for-X/verifier/verifier.dockerfile.template
@@ -25,7 +25,8 @@ RUN env DEBIAN_FRONTEND=noninteractive apt-get update \
 RUN sed -i "s|^\(  \"pccs_url\": \"https://\).*\(/sgx/certification.*\)|\1api.trustedservices.intel.com\2|g" \
     /etc/sgx_default_qcnl.conf
 
-RUN git clone --depth 1 --branch v1.6.1 https://github.com/gramineproject/gramine.git
+RUN git clone https://github.com/gramineproject/gramine.git \
+    && cd gramine && git checkout $(git tag --list 'v*.*' --sort=taggerdate | tail -1)
 
 ARG server_dcap_type="secret_prov_minimal"
 RUN if [ $server_dcap_type="secret_prov_pf" ]; then \

--- a/Intel-Confidential-Compute-for-X/workloads/pytorch/base_image_helper/helper.sh
+++ b/Intel-Confidential-Compute-for-X/workloads/pytorch/base_image_helper/helper.sh
@@ -10,8 +10,9 @@ cd $MY_PATH
 
 image_name='pytorch-encrypted'
 rm -rf examples
-git clone --depth 1 --branch v1.6 https://github.com/gramineproject/examples.git
+git clone https://github.com/gramineproject/examples.git
 cd examples/pytorch
+git checkout $(git tag --list 'v*.*' --sort=taggerdate | tail -1)
 
 # Download and save the pre-trained model
 python3 download-pretrained-model.py


### PR DESCRIPTION
With the new release of Gramine, old packages are replaced with new packages which use to cause verifier's build failure.

We always needed a PR to fix it after every Gramine release.

This issue was fixed partially with PR #82 where Gramine would use latest release package but GSC is still on old release.

Curated apps would still fail if GSC and Gramine versions are not same and also not compatible.

This PR tries to minimize the difference in releases of GSC and Gramine as latest tags are fetched automatically.

There could be the issue again if there is a time gap in creating the latest release tags for Gramine and GSC and in that time if a user curate the apps. We can think of placing a policy for creating Gramine and GSC tags at the same time.


After this PR, we won't need a contrib PR again and again after every Gramine releasefor moving to the latest Gramine release.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/contrib/83)
<!-- Reviewable:end -->
