### PR TITLE
Remove all deprecated manifest options

### DIFF
--- a/Examples/aks-attestation/aks-secret-prov-client.manifest
+++ b/Examples/aks-attestation/aks-secret-prov-client.manifest
@@ -5,7 +5,7 @@ loader.env.SECRET_PROVISION_SERVERS = { passthrough = true }
 loader.env.SECRET_PROVISION_CONSTRUCTOR = "1"
 loader.env.SECRET_PROVISION_CA_CHAIN_PATH = "ssl/ca.crt"
 
-sgx.remote_attestation = true
+sgx.remote_attestation = "dcap"
 
 sgx.allowed_files = [
   "file:/etc/ethers",

--- a/Examples/aks-python-helloworld/python.manifest
+++ b/Examples/aks-python-helloworld/python.manifest
@@ -1,2 +1,2 @@
 sgx.enclave_size = "512M"
-sgx.thread_num = 4
+sgx.max_threads = 4

--- a/Intel-Confidential-Compute-for-X/workloads/mysql/mysql.manifest.template
+++ b/Intel-Confidential-Compute-for-X/workloads/mysql/mysql.manifest.template
@@ -4,7 +4,6 @@
 # This file has basic set of values defined for graminizing mysql images. This manifest template
 # is used by `curation_script.sh` to create the user manifest file that will be passed to GSC.
 
-sgx.nonpie_binary = true
 sgx.enclave_size = "4G"
 sgx.max_threads = 128
 

--- a/Intel-Confidential-Compute-for-X/workloads/pytorch/pytorch.manifest.template
+++ b/Intel-Confidential-Compute-for-X/workloads/pytorch/pytorch.manifest.template
@@ -4,7 +4,6 @@
 # This file has basic set of values defined for graminizing PyTorch images. This manifest template
 # is used by `curation_script.sh` to create the user manifest file that will be passed to GSC.
 
-sgx.nonpie_binary = true
 sgx.enclave_size = "4G"
 sgx.max_threads = 128
 

--- a/Intel-Confidential-Compute-for-X/workloads/redis/redis.manifest.template
+++ b/Intel-Confidential-Compute-for-X/workloads/redis/redis.manifest.template
@@ -4,7 +4,6 @@
 # This file has basic set of values defined for graminizing Redis images. This manifest template
 # is used by `curation_script.sh` to create the user manifest file that will be passed to GSC.
 
-sgx.nonpie_binary = true
 sgx.enclave_size = "1024M"
 sgx.max_threads = 8
 

--- a/Intel-Confidential-Compute-for-X/workloads/sklearn/sklearn.manifest.template
+++ b/Intel-Confidential-Compute-for-X/workloads/sklearn/sklearn.manifest.template
@@ -4,7 +4,6 @@
 # This file has basic set of values defined for graminizing Scikit-learn images. This manifest template
 # is used by `curation_script.sh` to create the user manifest file that will be passed to GSC.
 
-sgx.nonpie_binary = true
 sgx.enclave_size = "16G"
 sgx.max_threads = 128
 

--- a/Intel-Confidential-Compute-for-X/workloads/tensorflow-serving/tensorflow-serving.manifest.template
+++ b/Intel-Confidential-Compute-for-X/workloads/tensorflow-serving/tensorflow-serving.manifest.template
@@ -5,7 +5,6 @@
 # template is used by `curation_script.sh` to create the user manifest file that will be passed to
 # GSC.
 
-sgx.nonpie_binary = true
 sgx.enclave_size = "64G"
 sgx.max_threads = 1024
 


### PR DESCRIPTION
Remove all deprecated manifest options reported by `gramine-manifest-check` tool.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/contrib/88)
<!-- Reviewable:end -->
